### PR TITLE
Fix crash when using vskernels.LinearLight class on HDR video

### DIFF
--- a/vstools/enums/color.py
+++ b/vstools/enums/color.py
@@ -1045,7 +1045,15 @@ class ColorRange(_ColorRangeMeta):
         return not self.value
 
 
-_transfer_matrix_map: dict[Transfer, Matrix] = {}
+_transfer_matrix_map: dict[Transfer, Matrix] = {
+    Transfer.SRGB: Matrix.RGB,
+    Transfer.BT709: Matrix.BT709,
+    Transfer.BT601: Matrix.SMPTE170M,
+    Transfer.BT470BG: Matrix.BT470BG,
+    Transfer.ST2084: Matrix.BT2020NC,
+    Transfer.BT2020_10bits: Matrix.BT2020NC,
+    Transfer.BT2020_12bits: Matrix.BT2020NC,
+}
 
 _primaries_matrix_map: dict[Primaries, Matrix] = {}
 


### PR DESCRIPTION
When instantiating the LinearLight class on a video using the PQ transfer function, the error "ValueError: 16 is not a valid Matrix" is currently thrown. This is due to the transfer-to-matrix mappings not being filled in, and currently only working correctly if the transfer and matrix int values are identical. Filling in this map resolves the crash.