### PR TITLE
scale_value: subtract lowest from peak during scaling

### DIFF
--- a/vstools/utils/scale.py
+++ b/vstools/utils/scale.py
@@ -124,7 +124,9 @@ def scale_value(
         return out_value
 
     input_peak = get_peak_value(in_fmt, chroma, range_in)
+    input_lowest = get_lowest_value(in_fmt, chroma, range_in)
     output_peak = get_peak_value(out_fmt, chroma, range_out)
+    output_lowest = get_lowest_value(out_fmt, chroma, range_out)
 
     if scale_offsets:
         if out_fmt.sample_type is vs.FLOAT and chroma:
@@ -132,7 +134,7 @@ def scale_value(
         elif range_out.is_full and range_in.is_limited:
             out_value -= 16 << (in_fmt.bits_per_sample - 8)
 
-    out_value *= output_peak / input_peak
+    out_value *= (output_peak - output_lowest) / (input_peak - input_lowest)
 
     if scale_offsets:
         if in_fmt.sample_type is vs.FLOAT and chroma:


### PR DESCRIPTION
Fix #99 
Possibly break/fix some scripts that use `scale_value`.
You can find the unit tests I took from [vsutils ](https://github.com/Irrational-Encoding-Wizardry/vsutil/blob/master/tests/test_vsutil.py#L178#L280).


<details>
  <summary>Unit tests</summary>
  
```py
import unittest
from vstools import ColorRange, scale_value

class Tests(unittest.TestCase):
    def test_scale_value(self):
        # no change
        self.assertEqual(scale_value(1, 8, 8, range_in=ColorRange.LIMITED, range_out=ColorRange.LIMITED), 1)
        self.assertEqual(scale_value(1, 8, 8, range_in=ColorRange.FULL, range_out=ColorRange.FULL), 1)
        self.assertEqual(scale_value(1, 32, 32, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED), 1)
        self.assertEqual(scale_value(1, 32, 32, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL), 1)

        # range conversion
        self.assertEqual(scale_value(219, 8, 8, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=False, chroma=False), 255)
        self.assertEqual(scale_value(255, 8, 8, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=False, chroma=False), 219)

        self.assertEqual(scale_value(224, 8, 8, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=False, chroma=True), 255)
        self.assertEqual(scale_value(255, 8, 8, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=False, chroma=True), 224)

        self.assertEqual(scale_value(235, 8, 8, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=True, chroma=False), 255)
        self.assertEqual(scale_value(255, 8, 8, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=True, chroma=False), 235)

        self.assertEqual(scale_value(240, 8, 8, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=True, chroma=True), 255)
        self.assertEqual(scale_value(255, 8, 8, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=True, chroma=True), 240)

        # int to int (upsample)
        self.assertEqual(scale_value(1, 8, 16, range_in=ColorRange.LIMITED, range_out=ColorRange.LIMITED, scale_offsets=False, chroma=False), 256)
        self.assertEqual(scale_value(1, 8, 16, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=False, chroma=False), 257)
        self.assertEqual(scale_value(219, 8, 16, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=False, chroma=False), 65535)
        self.assertEqual(scale_value(255, 8, 16, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=False, chroma=False), 219 << 8)

        self.assertEqual(scale_value(1, 8, 16, range_in=ColorRange.LIMITED, range_out=ColorRange.LIMITED, scale_offsets=False, chroma=True), 256)
        self.assertEqual(scale_value(1, 8, 16, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=False, chroma=True), 257)
        self.assertEqual(scale_value(224, 8, 16, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=False, chroma=True), 65535)
        self.assertEqual(scale_value(255, 8, 16, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=False, chroma=True), 224 << 8)

        self.assertEqual(scale_value(1, 8, 16, range_in=ColorRange.LIMITED, range_out=ColorRange.LIMITED, scale_offsets=True, chroma=False), 256)
        self.assertEqual(scale_value(1, 8, 16, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=True, chroma=False), 257)
        self.assertEqual(scale_value(235, 8, 16, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=True, chroma=False), 65535)
        self.assertEqual(scale_value(255, 8, 16, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=True, chroma=False), 235 << 8)

        self.assertEqual(scale_value(1, 8, 16, range_in=ColorRange.LIMITED, range_out=ColorRange.LIMITED, scale_offsets=True, chroma=True), 256)
        self.assertEqual(scale_value(1, 8, 16, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=True, chroma=True), 257)
        self.assertEqual(scale_value(240, 8, 16, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=True, chroma=True), 65535)
        self.assertEqual(scale_value(255, 8, 16, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=True, chroma=True), 240 << 8)

        # int to flt
        self.assertEqual(scale_value(1, 8, 32, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=False, chroma=False), 1 / 219)
        self.assertEqual(scale_value(1, 8, 32, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=False, chroma=False), 1 / 255)
        self.assertEqual(scale_value(219, 8, 32, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=False, chroma=False), 1)
        self.assertEqual(scale_value(255, 8, 32, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=False, chroma=False), 1)

        self.assertEqual(scale_value(1, 8, 32, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=False, chroma=True), 1 / 224)
        self.assertEqual(scale_value(1, 8, 32, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=False, chroma=True), 1 / 255)
        self.assertEqual(scale_value(224, 8, 32, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=False, chroma=True), 1)
        self.assertEqual(scale_value(255, 8, 32, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=False, chroma=True), 1)

        self.assertEqual(scale_value(1, 8, 32, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=True, chroma=False), (1 - 16) / 219)
        self.assertEqual(scale_value(1, 8, 32, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=True, chroma=False), 1 / 255)
        self.assertEqual(scale_value(235, 8, 32, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=True, chroma=False), 1)
        self.assertEqual(scale_value(255, 8, 32, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=True, chroma=False), 1)

        self.assertEqual(scale_value(1, 8, 32, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=True, chroma=True), (1 - 128) / 224)
        self.assertEqual(scale_value(1, 8, 32, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=True, chroma=True), (1 - 128) / 255)
        self.assertEqual(scale_value(240, 8, 32, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=True, chroma=True), 0.5)
        self.assertEqual(scale_value(255, 8, 32, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=True, chroma=True), (255 - 128) / 255)

        # int to int (downsample)
        self.assertEqual(scale_value(256, 16, 8, range_in=ColorRange.LIMITED, range_out=ColorRange.LIMITED, scale_offsets=False, chroma=False), 1)
        self.assertEqual(scale_value(257, 16, 8, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=False, chroma=False), 1)
        self.assertEqual(scale_value(65535, 16, 8, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=False, chroma=False), 219)
        self.assertEqual(scale_value(219 << 8, 16, 8, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=False, chroma=False), 255)

        self.assertEqual(scale_value(256, 16, 8, range_in=ColorRange.LIMITED, range_out=ColorRange.LIMITED, scale_offsets=False, chroma=True), 1)
        self.assertEqual(scale_value(257, 16, 8, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=False, chroma=True), 1)
        self.assertEqual(scale_value(65535, 16, 8, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=False, chroma=True), 224)
        self.assertEqual(scale_value(224 << 8, 16, 8, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=False, chroma=True), 255)

        self.assertEqual(scale_value(256, 16, 8, range_in=ColorRange.LIMITED, range_out=ColorRange.LIMITED, scale_offsets=True, chroma=False), 1)
        self.assertEqual(scale_value(257, 16, 8, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=True, chroma=False), 1)
        self.assertEqual(scale_value(65535, 16, 8, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=True, chroma=False), 235)
        self.assertEqual(scale_value(235 << 8, 16, 8, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=True, chroma=False), 255)

        self.assertEqual(scale_value(256, 16, 8, range_in=ColorRange.LIMITED, range_out=ColorRange.LIMITED, scale_offsets=True, chroma=True), 1)
        self.assertEqual(scale_value(257, 16, 8, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=True, chroma=True), 1)
        self.assertEqual(scale_value(65535, 16, 8, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=True, chroma=True), 240)
        self.assertEqual(scale_value(240 << 8, 16, 8, range_in=ColorRange.LIMITED, range_out=ColorRange.FULL, scale_offsets=True, chroma=True), 255)

        # flt to int
        self.assertEqual(scale_value(1 / 219, 32, 8, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=False, chroma=False), 1)
        self.assertEqual(scale_value(1 / 255, 32, 8, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=False, chroma=False), 1)
        self.assertEqual(scale_value(1, 32, 8, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=False, chroma=False), 219)
        self.assertEqual(scale_value(1, 32, 8, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=False, chroma=False), 255)

        self.assertEqual(scale_value(1 / 224, 32, 8, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=False, chroma=True), 1)
        self.assertEqual(scale_value(1 / 255, 32, 8, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=False, chroma=True), 1)
        self.assertEqual(scale_value(1, 32, 8, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=False, chroma=True), 224)
        self.assertEqual(scale_value(1, 32, 8, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=False, chroma=True), 255)

        self.assertEqual(scale_value((1 - 16) / 219, 32, 8, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=True, chroma=False), 1)
        self.assertEqual(scale_value(1 / 255, 32, 8, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=True, chroma=False), 1)
        self.assertEqual(scale_value(1, 32, 8, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=True, chroma=False), 235)
        self.assertEqual(scale_value(1, 32, 8, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=True, chroma=False), 255)

        self.assertEqual(scale_value((1 - 128) / 224, 32, 8, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=True, chroma=True), 1)
        self.assertEqual(scale_value((1 - 128) / 255, 32, 8, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=True, chroma=True), 1)
        self.assertEqual(scale_value(0.5, 32, 8, range_in=ColorRange.FULL, range_out=ColorRange.LIMITED, scale_offsets=True, chroma=True), 240)
        self.assertEqual(scale_value((255 - 128) / 255, 32, 8, range_in=ColorRange.FULL, range_out=ColorRange.FULL, scale_offsets=True, chroma=True), 255)


if __name__ == '__main__':
    unittest.main()
```
  
</details>
