### PR TITLE
replace_ranges: fix incorrect output length when using exclusive

### DIFF
--- a/vstools/utils/ranges.py
+++ b/vstools/utils/ranges.py
@@ -210,7 +210,7 @@ def replace_ranges(
 
         a_ranges = invert_ranges(clip_b, clip_a, b_ranges)
 
-        a_trims = [clip_a[start:end + shift] for start, end in a_ranges]
+        a_trims = [clip_a[max(0, start - exclusive):end + shift + exclusive] for start, end in a_ranges]
         b_trims = [clip_b[start:end + shift] for start, end in b_ranges]
 
         if a_ranges:


### PR DESCRIPTION
The more ranges you specify, the less frames you get when using `exclusive=True`