### PR TITLE
get_w/h: Add fraction as ar type

### DIFF
--- a/vstools/utils/info.py
+++ b/vstools/utils/info.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from fractions import Fraction
-from typing import Any, overload
+from typing import Any, SupportsFloat, overload
 
 import vapoursynth as vs
 from stgpytools import fallback, mod_x
@@ -194,12 +194,7 @@ def get_subsampling(clip: VideoFormatT | HoldsVideoFormatT, /) -> str | None:
 
 
 @overload
-def get_w(height: float, ar: float = 16 / 9, /, mod: int = 2) -> int:
-    ...
-
-
-@overload
-def get_w(height: float, ar: Fraction, /, mod: int | None = None) -> int:
+def get_w(height: float, ar: SupportsFloat = 16 / 9, /, mod: int = 2) -> int:
     ...
 
 
@@ -209,7 +204,7 @@ def get_w(height: float, ref: vs.VideoNode | vs.VideoFrame, /, mod: int | None =
 
 
 def get_w(
-    height: float, ar_or_ref: vs.VideoNode | vs.VideoFrame | Fraction | float = 16 / 9, /, mod: int | None = None
+    height: float, ar_or_ref: vs.VideoNode | vs.VideoFrame | SupportsFloat = 16 / 9, /, mod: int | None = None
 ) -> int:
     """
     Calculate the width given a height and an aspect ratio.
@@ -233,7 +228,7 @@ def get_w(
         aspect_ratio = ref.width / ref.height  # type: ignore
         mod = fallback(mod, ref.format.subsampling_w and 2 << ref.format.subsampling_w)  # type: ignore
     else:
-        aspect_ratio = float(ar_or_ref)  # type:ignore
+        aspect_ratio = ar_or_ref  # type:ignore
 
         if mod is None:
             mod = 0 if height % 2 else 2
@@ -247,12 +242,7 @@ def get_w(
 
 
 @overload
-def get_h(width: float, ar: float = 16 / 9, /, mod: int = 2) -> int:
-    ...
-
-
-@overload
-def get_h(width: float, ref: Fraction, /, mod: int | None = None) -> int:
+def get_h(width: float, ar: SupportsFloat = 16 / 9, /, mod: int = 2) -> int:
     ...
 
 
@@ -262,7 +252,7 @@ def get_h(width: float, ref: vs.VideoNode | vs.VideoFrame, /, mod: int | None = 
 
 
 def get_h(
-    width: float, ar_or_ref: vs.VideoNode | vs.VideoFrame | Fraction | float = 16 / 9, /, mod: int | None = None
+    width: float, ar_or_ref: vs.VideoNode | vs.VideoFrame | SupportsFloat = 16 / 9, /, mod: int | None = None
 ) -> int:
     """
     Calculate the height given a width and an aspect ratio.
@@ -286,7 +276,7 @@ def get_h(
         aspect_ratio = ref.height / ref.width  # type: ignore
         mod = fallback(mod, ref.format.subsampling_h and 2 << ref.format.subsampling_h)  # type: ignore
     else:
-        aspect_ratio = 1.0 / float(ar_or_ref)  # type: ignore
+        aspect_ratio = 1.0 / ar_or_ref  # type: ignore
 
         if mod is None:
             mod = 0 if width % 2 else 2

--- a/vstools/utils/info.py
+++ b/vstools/utils/info.py
@@ -199,11 +199,18 @@ def get_w(height: float, ar: float = 16 / 9, /, mod: int = 2) -> int:
 
 
 @overload
+def get_w(height: float, ar: Fraction, /, mod: int | None = None) -> int:
+    ...
+
+
+@overload
 def get_w(height: float, ref: vs.VideoNode | vs.VideoFrame, /, mod: int | None = None) -> int:
     ...
 
 
-def get_w(height: float, ar_or_ref: vs.VideoNode | vs.VideoFrame | float = 16 / 9, /, mod: int | None = None) -> int:
+def get_w(
+    height: float, ar_or_ref: vs.VideoNode | vs.VideoFrame | Fraction | float = 16 / 9, /, mod: int | None = None
+) -> int:
     """
     Calculate the width given a height and an aspect ratio.
 
@@ -226,7 +233,7 @@ def get_w(height: float, ar_or_ref: vs.VideoNode | vs.VideoFrame | float = 16 / 
         aspect_ratio = ref.width / ref.height  # type: ignore
         mod = fallback(mod, ref.format.subsampling_w and 2 << ref.format.subsampling_w)  # type: ignore
     else:
-        aspect_ratio = ar_or_ref
+        aspect_ratio = float(ar_or_ref)  # type:ignore
 
         if mod is None:
             mod = 0 if height % 2 else 2
@@ -245,11 +252,18 @@ def get_h(width: float, ar: float = 16 / 9, /, mod: int = 2) -> int:
 
 
 @overload
+def get_h(width: float, ref: Fraction, /, mod: int | None = None) -> int:
+    ...
+
+
+@overload
 def get_h(width: float, ref: vs.VideoNode | vs.VideoFrame, /, mod: int | None = None) -> int:
     ...
 
 
-def get_h(width: float, ar_or_ref: vs.VideoNode | vs.VideoFrame | float = 16 / 9, /, mod: int | None = None) -> int:
+def get_h(
+    width: float, ar_or_ref: vs.VideoNode | vs.VideoFrame | Fraction | float = 16 / 9, /, mod: int | None = None
+) -> int:
     """
     Calculate the height given a width and an aspect ratio.
 
@@ -272,7 +286,7 @@ def get_h(width: float, ar_or_ref: vs.VideoNode | vs.VideoFrame | float = 16 / 9
         aspect_ratio = ref.height / ref.width  # type: ignore
         mod = fallback(mod, ref.format.subsampling_h and 2 << ref.format.subsampling_h)  # type: ignore
     else:
-        aspect_ratio = 1.0 / ar_or_ref  # type: ignore
+        aspect_ratio = 1.0 / float(ar_or_ref)  # type: ignore
 
         if mod is None:
             mod = 0 if width % 2 else 2


### PR DESCRIPTION
This way, stuff like SAR/DAR can also be passed and very trivially be used to calculate the width/height.