### PR TITLE
Print progress reports to stderr

### DIFF
--- a/vstools/functions/progress.py
+++ b/vstools/functions/progress.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from types import TracebackType
 from typing import overload
 
+from rich.console import Console
 from rich.progress import BarColumn, Progress, ProgressColumn, Task, TaskID, TextColumn, TimeRemainingColumn
 from rich.text import Text
 
@@ -81,4 +82,5 @@ def get_render_progress(title: str | None = None, total: int | None = None) -> R
         TextColumn("{task.percentage:>3.02f}%"),
         FPSColumn(),
         TimeRemainingColumn(),
+        console=Console(stderr=True),
     )


### PR DESCRIPTION
Running `vspipe -c y4m script.vpy - | ffmpeg -i pipe: -c ffv1 out.mkv` makes vspipe write the filtered video to stdout, which is redirected to ffmpeg's stdin by the pipe.

Unfortunately, the rich package defaults to writing progress reports to stdout as well. If the script calls any function that produces a progress report, it gets mixed into the video stream and corrupts it.

This configures rich to write to stderr instead, so that the reports always end up on the terminal (unless stderr is redirected manually).