### PR TITLE
Add dependency checking helpers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setuptools.setup(
         f'{package_name}.exceptions',
         f'{package_name}.functions',
         f'{package_name}.types',
-        f'{package_name}.utils'
+        f'{package_name}.utils',
+        f'{package_name}.utils.dependency',
     ],
     package_data={
         package_name: ['py.typed', 'utils/*.json']

--- a/vstools/exceptions/__init__.py
+++ b/vstools/exceptions/__init__.py
@@ -1,5 +1,6 @@
 from .base import *  # noqa: F401, F403
 from .color import *  # noqa: F401, F403
+from .dependencies import *  # noqa: F401, F403
 from .enum import *  # noqa: F401, F403
 from .file import *  # noqa: F401, F403
 from .generic import *  # noqa: F401, F403

--- a/vstools/exceptions/dependencies.py
+++ b/vstools/exceptions/dependencies.py
@@ -1,0 +1,77 @@
+from typing import Any
+
+from stgpytools import CustomError, FuncExceptT, SupportsString
+
+__all__: list[str] = [
+    'CustomDependencyError',
+    'MissingPluginsError', 'MissingPluginFunctionsError',
+    'MissingPackagesError'
+]
+
+
+class CustomDependencyError(CustomError, ImportError):
+    """Raised when there's a general dependency error."""
+
+    def __init__(
+        self, func: FuncExceptT, deps: str | list[str] | ImportError,
+        message: SupportsString = "Missing dependencies: '{deps}'!",
+        **kwargs: Any
+    ) -> None:
+        """
+        :param func:        Function this error was raised from.
+        :param deps:        Either the raised error or the names of the missing package.
+        :param message:     Custom error message.
+        """
+
+        super().__init__(message, func, deps=deps, **kwargs)
+
+
+class MissingPluginsError(CustomDependencyError):
+    """Raised when there's missing plugins."""
+
+    def __init__(
+        self, func: FuncExceptT, plugins: str | list[str] | ImportError,
+        message: SupportsString = "Missing plugins '{deps}'!",
+        **kwargs: Any
+    ) -> None:
+        if isinstance(plugins, list) and len(plugins) == 1:
+            if isinstance(message, str):
+                message = message.replace("plugins", "plugin")
+
+            plugins = plugins[0]
+
+        super().__init__(func, plugins, message, **kwargs)
+
+
+class MissingPluginFunctionsError(CustomDependencyError):
+    """Raised when a plugin is missing functions."""
+
+    def __init__(
+        self, func: FuncExceptT, plugin: str, functions: str | list[str],
+        message: SupportsString = "'{plugin}' plugin is missing functions '{deps}'!",
+        **kwargs: Any
+    ) -> None:
+        if isinstance(functions, list) and len(functions) == 1:
+            if isinstance(message, str):
+                message = message.replace('functions', 'function')
+
+            functions = functions[0]
+
+        super().__init__(func, functions, message, plugin=plugin, **kwargs)
+
+
+class MissingPackagesError(CustomDependencyError):
+    """Raised when there's missing packages."""
+
+    def __init__(
+        self, func: FuncExceptT, packages: str | list[str] | ImportError,
+        message: SupportsString = "Missing packages '{deps}'!",
+        **kwargs: Any
+    ) -> None:
+        if isinstance(packages, list) and len(packages) == 1:
+            if isinstance(message, str):
+                message = message.replace("packages", "package")
+
+            packages = packages[0]
+
+        super().__init__(func, packages, message, **kwargs)

--- a/vstools/types/file.py
+++ b/vstools/types/file.py
@@ -21,5 +21,10 @@ __all__ = [
     'OpenTextMode',
     'OpenBinaryMode',
 
-    'SPath', 'SPathLike'
+    'SPath', 'SPathLike',
+
+    'DEP_URL'
 ]
+
+DEP_URL = str
+"""A string representing a URL to download a dependency from."""

--- a/vstools/utils/dependency/__init__.py
+++ b/vstools/utils/dependency/__init__.py
@@ -1,0 +1,3 @@
+from .function import *  # noqa: F401, F403
+from .packages import *  # noqa: F401, F403
+from .plugin import *  # noqa: F401, F403

--- a/vstools/utils/dependency/function.py
+++ b/vstools/utils/dependency/function.py
@@ -1,0 +1,104 @@
+from functools import wraps
+from typing import Any, Callable
+
+from stgpytools import F, FuncExceptT
+
+from ... import core
+from ...exceptions.dependencies import MissingPluginFunctionsError
+from .plugin import check_installed_plugins
+
+__all__: list[str] = [
+    'check_installed_plugin_functions',
+    'required_plugin_functions'
+]
+
+
+def check_installed_plugin_functions(
+    plugin: str,
+    functions: str | list[str] = [],
+    strict: bool = True,
+    func_except: FuncExceptT | None = None
+) -> list[str]:
+    """
+    Check if the given plugins are installed.
+
+    Example usage:
+
+    .. code-block:: python
+
+        >>> check_installed_plugin_functions('descale', ['Bicubic', 'Debicubic'])
+
+        >>> if check_installed_plugins('descale', ['Bicubic', 'Debicubic'], strict=False):
+        ...     print('Missing functions for plugin! Please update!')
+
+    :param plugin:          The plugin to check.
+    :param plugins:         A list of functions to check for.
+    :param strict:          If True, raises an error if any of the plugins are missing.
+                            Default: True.
+    :param func_except:     Function returned for custom error handling.
+                            This should only be set by VS package developers.
+
+    :return:                A list of all missing functions if strict=False, else raises an error.
+    """
+
+    if not functions:
+        return list[str]()
+
+    func = func_except or check_installed_plugin_functions
+
+    check_installed_plugins(plugin, True, func)
+
+    if isinstance(functions, str):
+        functions = [functions]
+
+    plg = getattr(core, plugin)
+
+    missing = [
+        plugin_func for plugin_func in functions if not hasattr(plg, plugin_func)
+    ]
+
+    if not missing or not strict:
+        return missing
+
+    raise MissingPluginFunctionsError(func, plugin, missing, reason=f'{strict=}')
+
+
+def required_plugin_functions(
+    plugin: str, functions: list[str] = [],
+    func_except: FuncExceptT | None = None
+) -> Callable[[F], F]:
+    """
+    Decorator to ensure that the specified plugin has specific functions.
+
+    The plugin and list of functions will be stored in the function's `required_plugin_functions` attribute.
+
+    Example usage:
+
+    .. code-block:: python
+
+        >>> @required_plugin_functions('descale', ['Bicubic', 'Debicubic'])
+        >>> def func(clip: vs.VideoNode) -> vs.VideoNode:
+        ...     return clip
+
+        >>> print(func.required_plugin_functions)
+        ... ('descale', ['Bicubic', 'Debicubic'])
+
+    For more information, see :py:func:`check_installed_plugin_functions`.
+
+    :param plugin:          The plugin to check.
+    :param functions:       A list of functions to check for.
+    :param func_except:     Function returned for custom error handling.
+                            This should only be set by VS package developers.
+    """
+
+    def decorator(func: F) -> F:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            check_installed_plugin_functions(plugin, functions, True, func_except or func)
+            func.required_plugin_functions = (plugin, functions)  # type:ignore
+
+            return func(*args, **kwargs)
+
+        return wrapper  # type:ignore
+
+    return decorator

--- a/vstools/utils/dependency/packages.py
+++ b/vstools/utils/dependency/packages.py
@@ -1,0 +1,106 @@
+from functools import wraps
+from typing import Any, Callable
+
+from stgpytools import F, FuncExceptT
+
+from ...exceptions import MissingPackagesError
+from ...types import DEP_URL
+
+__all__: list[str] = [
+    'check_installed_packages',
+    'required_packages'
+]
+
+
+def check_installed_packages(
+    packages: str | list[str] | dict[str, DEP_URL] = [],
+    strict: bool = True,
+    func_except: FuncExceptT | None = None
+) -> list[str]:
+    """
+    Check if the given packages are installed.
+
+    Example usage:
+
+    .. code-block:: python
+
+        >>> check_installed_packages(['lvsfunc', 'vstools'])
+
+        >>> check_installed_packages({'lvsfunc': 'pip install lvsfunc'})
+
+        >>> if check_installed_packages(['lvsfunc', 'vstools'], strict=False):
+        ...     print('Missing packages!')
+
+    :param packages:        A list of packages to check for. If a dict is passed,
+                            the values are treated as either a URL or a pip command to download the package.
+    :param strict:          If True, raises an error if any of the packages are missing.
+                            Default: True.
+    :param func_except:     Function returned for custom error handling.
+                            This should only be set by VS package developers.
+
+    :return:                A list of all missing packages if strict=False, else raises an error.
+    """
+
+    if not packages:
+        return list[str]()
+
+    if isinstance(packages, str):
+        packages = [packages]
+
+    missing = list[str]()
+
+    for pkg in (packages.keys() if isinstance(packages, dict) else packages):
+        try:
+            __import__(pkg)
+        except ImportError:
+            missing.append(f'{pkg} ({packages[pkg]})' if isinstance(packages, dict) else pkg)
+
+    if not missing or not strict:
+        return missing
+
+    raise MissingPackagesError(func_except or check_installed_packages, missing, reason=f'{strict=}')
+
+
+def required_packages(
+    packages: list[str] | dict[str, DEP_URL] = [],
+    func_except: FuncExceptT | None = None
+) -> Callable[[F], F]:
+    """
+    Decorator to ensure that specified packages are installed.
+
+    The list of packages will be stored in the function's `required_packages` attribute.
+
+    Example usage:
+
+    .. code-block:: python
+
+        >>> @required_packages(['lvsfunc', 'vstools'])
+        >>> def func(clip: vs.VideoNode) -> vs.VideoNode:
+        ...     return clip
+
+        >>> print(func.required_packages)
+        ... ['lvsfunc', 'vstools']
+
+        >>> @required_packages({'lvsfunc': 'pip install lvsfunc'})
+        >>> def func(clip: vs.VideoNode) -> vs.VideoNode:
+        ...     return clip
+
+    For more information, see :py:func:`check_installed_packages`.
+
+    :param packages:        A list of packages to check for. If a dict is passed,
+                            the values are treated as either a URL or a pip command to download the package.
+    :param func_except:     Function returned for custom error handling.
+                            This should only be set by VS package developers.
+    """
+
+    def decorator(func: F) -> F:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            check_installed_packages(packages, True, func_except or func)
+            func.required_packages = packages  # type:ignore
+
+            return func(*args, **kwargs)
+
+        return wrapper  # type:ignore
+
+    return decorator

--- a/vstools/utils/dependency/plugin.py
+++ b/vstools/utils/dependency/plugin.py
@@ -1,0 +1,105 @@
+from functools import wraps
+from typing import Any, Callable
+
+from stgpytools import F, FuncExceptT
+
+from ... import core
+from ...exceptions import MissingPluginsError
+from ...types import DEP_URL
+
+__all__: list[str] = [
+    'check_installed_plugins',
+    'required_plugins'
+]
+
+
+def check_installed_plugins(
+    plugins: str | list[str] | dict[str, DEP_URL] = [],
+    strict: bool = True,
+    func_except: FuncExceptT | None = None
+) -> list[str]:
+    """
+    Check if the given plugins are installed.
+
+    Example usage:
+
+    .. code-block:: python
+
+        >>> check_installed_plugins(['resize', 'descale'])
+
+        >>> check_installed_plugins({'descale': 'https://github.com/Jaded-Encoding-Thaumaturgy/vapoursynth-descale'})
+
+        >>> if check_installed_plugins(['resize', 'descale'], strict=False):
+        ...     print('Missing plugins!')
+
+    :param plugins:         A list of plugins to check for. If a dict is passed,
+                            the values are treated as URLs to download the plugin.
+    :param strict:          If True, raises an error if any of the plugins are missing.
+                            Default: True.
+    :param func_except:     Function returned for custom error handling.
+                            This should only be set by VS package developers.
+
+    :return:                A list of all missing plugins if strict=False, else raises an error.
+    """
+
+    if not plugins:
+        return list[str]()
+
+    if isinstance(plugins, str):
+        plugins = [plugins]
+
+    missing = [
+        f'{plugin} ({plugins[plugin]})' if isinstance(plugins, dict) else plugin
+        for plugin in (plugins.keys() if isinstance(plugins, dict) else plugins)
+        if not hasattr(core, plugin)
+    ]
+
+    if not missing or not strict:
+        return missing
+
+    raise MissingPluginsError(func_except or check_installed_plugins, missing, reason=f'{strict=}')
+
+
+def required_plugins(
+    plugins: list[str] | dict[str, DEP_URL] = [],
+    func_except: FuncExceptT | None = None
+) -> Callable[[F], F]:
+    """
+    Decorator to ensure that specified plugins are installed.
+
+    The list of plugins will be stored in the function's `required_plugins` attribute.
+
+    Example usage:
+
+    .. code-block:: python
+
+        >>> @required_plugins(['resize', 'descale'])
+        >>> def func(clip: vs.VideoNode) -> vs.VideoNode:
+        ...     return clip
+
+        >>> print(func.required_plugins)
+        ... ['resize', 'descale']
+
+        >>> @required_plugins({'descale': 'https://github.com/Jaded-Encoding-Thaumaturgy/vapoursynth-descale'})
+        >>> def func(clip: vs.VideoNode) -> vs.VideoNode:
+        ...     return clip
+
+    For more information, see :py:func:`check_installed_plugins`.
+
+    :param plugins:         A list of plugins to check for. If a dict is passed,
+                            the values are treated as URLs to download the plugin.
+    :param func_except:     Function returned for custom error handling.
+                            This should only be set by VS package developers.
+    """
+
+    def decorator(func: F) -> F:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            check_installed_plugins(plugins, True, func_except or func)
+            func.required_plugins = plugins  # type:ignore
+
+            return func(*args, **kwargs)
+
+        return wrapper  # type:ignore
+
+    return decorator


### PR DESCRIPTION
Lightly modified lvsfunc code. Useful for func devs to check for dependencies (most notably plugin deps).

Additional things to consider:

- Support for classes and methods
- xor support (either x plugin or y) (this could be implemented as a tuple or something, where if either of the plugins is installed, it passes?)

If this PR gets accepted, I'll also try to make a concentrated effort to add dep checks for a number of (common) JET functions/packages.