### PR TITLE
Add packet collection function + util

### DIFF
--- a/vstools/functions/__init__.py
+++ b/vstools/functions/__init__.py
@@ -4,6 +4,7 @@ from .file import *  # noqa: F401, F403
 from .funcs import *  # noqa: F401, F403
 from .heuristics import *  # noqa: F401, F403
 from .normalize import *  # noqa: F401, F403
+from .packets import *  # noqa: F401, F403
 from .progress import *  # noqa: F401, F403
 from .render import *  # noqa: F401, F403
 from .timecodes import *  # noqa: F401, F403

--- a/vstools/functions/packets.py
+++ b/vstools/functions/packets.py
@@ -8,9 +8,9 @@ from subprocess import PIPE, Popen
 from tempfile import NamedTemporaryFile
 from typing import Self, TypedDict
 
+import vapoursynth as vs
 from stgpytools import CustomValueError, DependencyNotFoundError, FuncExceptT, SPath, SPathLike
 
-from .. import core, vs
 from ..functions import Keyframes, PackageStorage
 from ..utils import get_clip_filepath
 
@@ -46,7 +46,7 @@ class VideoPackets(list[int]):
             raise DependencyNotFoundError(func, 'ffprobe', 'Could not find {package}! Make sure it\'s in your PATH!')
 
         proc = Popen([
-            'ffprobe', '-hide_banner', '-show_frames', '-show_streams', '-threads', str(core.num_threads),
+            'ffprobe', '-hide_banner', '-show_frames', '-show_streams', '-threads', str(vs.core.num_threads),
             '-loglevel', 'quiet', '-print_format', 'json', '-select_streams', 'v:0', src_file
         ], stdout=PIPE)
 

--- a/vstools/functions/packets.py
+++ b/vstools/functions/packets.py
@@ -26,13 +26,13 @@ packets_storage = PackageStorage(package_name='packets')
 class ScenePacketStats(TypedDict):
     """A class representing the packet size statistics for a scene in a video."""
 
-    pkt_scene_avg_size: float
+    PktSceneAvgSize: float
     """The average packet size for the scene."""
 
-    pkt_scene_max_size: float
+    PktSceneMaxSize: float
     """The maximum packet size for the scene."""
 
-    pkt_scene_min_size: float
+    PktSceneMinSize: float
     """The minimum packet size for the scene."""
 
 
@@ -188,9 +188,9 @@ class VideoPackets(list[int]):
 
                 stats.append(
                     ScenePacketStats(
-                        pkt_scene_avg_size=sum(pkt_scenes) / len(pkt_scenes),
-                        pkt_scene_max_size=max(pkt_scenes),
-                        pkt_scene_min_size=min(pkt_scenes)
+                        PktSceneAvgSize=sum(pkt_scenes) / len(pkt_scenes),
+                        PktSceneMaxSize=max(pkt_scenes),
+                        PktSceneMinSize=min(pkt_scenes)
                     )
                 )
         except ValueError as e:
@@ -222,7 +222,7 @@ class VideoPackets(list[int]):
             if (pkt_size := self[n]) < 0:
                 warnings.warn(f'{func}: \'Frame {n} bitrate could not be determined!\'')
 
-            return clip.std.SetFrameProps(pkt_size=pkt_size)
+            return clip.std.SetFrameProps(PktSize=pkt_size)
 
         if not keyframes:
             return clip.std.FrameEval(_set_sizes_props)
@@ -232,15 +232,15 @@ class VideoPackets(list[int]):
                 warnings.warn(f'{func}: \'Frame {n} bitrate could not be determined!\'')
 
             try:
-                return clip.std.SetFrameProps(pkt_size=pkt_size, **scenestats[keyframes.scenes.indices[n]])
+                return clip.std.SetFrameProps(PktSize=pkt_size, **scenestats[keyframes.scenes.indices[n]])
             except Exception:
                 warnings.warn(f'{func}: \'Could not find stats for a section... (Frame: {n})\'')
 
                 return clip.std.SetFrameProps(
-                    pkt_size=-1,
-                    pkt_scene_avg_size=-1,
-                    pkt_scene_max_size=-1,
-                    pkt_scene_min_size=-1
+                    PktSize=-1,
+                    PktSceneAvgSize=-1,
+                    PktSceneMaxSize=-1,
+                    PktSceneMinSize=-1
                 )
 
         scenestats = self.get_scenestats(keyframes)

--- a/vstools/functions/packets.py
+++ b/vstools/functions/packets.py
@@ -33,9 +33,14 @@ class VideoPackets(list[int]):
 
     @classmethod
     def from_video(
-        cls, src_file: SPathLike, out_file: SPathLike, offset: int = 0, *, func: FuncExceptT | None = None
+        cls, src_file: SPathLike, out_file: SPathLike | None = None,
+        offset: int = 0, *, func: FuncExceptT | None = None
     ) -> Self:
         func = func or cls.from_video
+
+        if out_file is None:
+            src_file = SPath(src_file)
+            out_file = src_file.with_stem(src_file.stem + '_packets').with_suffix('.txt')
 
         if video_packets := cls.from_file(out_file, func=func):
             return video_packets

--- a/vstools/functions/packets.py
+++ b/vstools/functions/packets.py
@@ -1,0 +1,222 @@
+import io
+import json
+import shutil
+import subprocess as sp
+import warnings
+from functools import partial
+from tempfile import NamedTemporaryFile
+from typing import overload
+
+from stgpytools import (CustomValueError, DependencyNotFoundError, FuncExceptT,
+                        SPath, SPathLike)
+
+from .. import core, vs
+from ..functions import Keyframes
+from ..utils import get_file_from_clip
+
+__all__ = [
+    'get_packet_sizes',
+    'get_packet_scene_stats',
+]
+
+
+@overload
+def get_packet_sizes(
+    clip: vs.VideoNode,
+    src_file: SPathLike | None = None,
+    out_file: SPathLike | None = None,
+    keyframes: Keyframes | None = None,
+    offset: int = 0,
+    return_packet_sizes: bool = False,
+    func_except: FuncExceptT | None = None
+) -> vs.VideoNode:
+    ...
+
+
+@overload
+def get_packet_sizes(  # type:ignore[misc]
+    clip: vs.VideoNode,
+    src_file: SPathLike | None = None,
+    out_file: SPathLike | None = None,
+    keyframes: Keyframes | None = None,
+    offset: int = 0,
+    return_packet_sizes: bool = True,
+    func_except: FuncExceptT | None = None
+) -> list[int]:
+    ...
+
+
+def get_packet_sizes(
+    clip: vs.VideoNode,
+    src_file: SPathLike | None = None,
+    out_file: SPathLike | None = None,
+    keyframes: Keyframes | None = None,
+    offset: int = 0,
+    return_packet_sizes: bool = False,
+    func_except: FuncExceptT | None = None
+) -> vs.VideoNode | list[int]:
+    """
+    A simple function to read and add frame packet sizes as frame props.
+
+    "Packet sizes" are the size of individual frames. These can be used to calculate the average bitrate of a clip
+    or a scene, and to process certain frames differently depending on how much bitrate is allocated to specific
+    sections.
+
+    If `out_file` is set, the results will be written to a file. This file will be read in subsequent calls to save
+    time. This is useful when you're working with a large clip and you don't want to call ffprobe every time you
+    refresh the preview.
+
+    If a Keyframes object is passed, additional scene-based frame props will be added. These are the min, max, and
+    average packet sizes of a scene based on these Keyframes.
+
+    If a non-zero `offset` is set, the function will trim the list of packet sizes to match. Negative values will
+    instead set the packet sizes for the first `offset` frames to -1. This is intended to be used with trimmed clips.
+
+    Dependencies:
+
+    * `ffprobe <https://ffmpeg.org/download.html>`_
+
+    :param clip:                    Clip to add the properties to.
+    :param src_file:                The path to the original file that was indexed.
+                                    If None, tries to read the `idx_filepath` property from `clip`.
+                                    Will throw an error if it can't find either.
+                                    This parameter is ignored if `out_file` is set and a file can be read.
+    :param out_file:                Output file for packet sizes. If set, the results will be written to that file,
+                                    and also read from that file in subsequent calls. This saves us from having to
+                                    call ffprobe every time you refresh the preview.
+    :param keyframes:               A Keyframes object to identify scene changes. If set, scene-based metrics will
+                                    be calculated and added as frame props alongside the `pkt_size` frame prop.
+    :param offset:                  Offset to trim or duplicate the list of packet sizes. This is useful when you're
+                                    working with a trimmed clip. Should be the same value as your trim at the start
+                                    of the clip. Negative values will set the packet sizes for the first `offset`
+                                    frames to -1 instead.
+    :param return_packet_sizes:     If set to True, the function will return the packet sizes as a list of integers.
+                                    To get the scene-based stats, you will need to pass this list to the
+                                    `get_packet_scene_stats` function along with a Keyframes object.
+                                    Default: False.
+    :param func_except:             Function returned for custom error handling.
+                                    This should only be set by VS package developers.
+
+    :return:                        Input clip with `pkt_size` frame props added, with optionally scene-based packet
+                                    stats frame props added on top. if `return_packet_sizes` is set to True, it will
+                                    return the packet sizes as a list of integers instead.
+    """
+
+    func = func_except or get_packet_sizes
+
+    if out_file is not None and SPath(out_file).exists():
+        with open(out_file, 'r+') as f:
+            pkt_sizes = [int(pkt) for pkt in f.readlines()]
+    else:
+        sfile = get_file_from_clip(clip, src_file, func_except=func)
+        pkt_sizes = _get_frames(sfile, func)  # type:ignore[arg-type]
+
+    if out_file is not None and not (sout := SPath(out_file)).exists():
+        print(f'Writing packet sizes to \'{sout.absolute()}\'...')
+
+        sout.parent.mkdir(parents=True, exist_ok=True)
+        sout.write_text('\n'.join([str(pkt) for pkt in pkt_sizes]), 'utf-8', newline='\n')
+
+    if offset < 0:
+        pkt_sizes = [-1] * -offset + pkt_sizes
+    elif offset > 0:
+        pkt_sizes = pkt_sizes[offset:]
+
+    if return_packet_sizes:
+        return pkt_sizes
+
+    def _set_sizes_props(n: int, clip: vs.VideoNode, pkt_sizes: list[int]) -> vs.VideoNode:
+        if (pkt_size := pkt_sizes[n]) < 0:
+            warnings.warn(f'{func}: \'Frame {n} bitrate could not be determined!\'')
+
+        return clip.std.SetFrameProps(pkt_size=pkt_size)
+
+    if not keyframes:
+        return clip.std.FrameEval(partial(_set_sizes_props, clip=clip, pkt_sizes=pkt_sizes))
+
+    def _set_scene_stats(n: int, clip: vs.VideoNode, stats: list[dict[str, int]]) -> vs.VideoNode:
+        if (pkt_size := pkt_sizes[n]) < 0:
+            warnings.warn(f'{func}: \'Frame {n} bitrate could not be determined!\'')
+
+        try:
+            return clip.std.SetFrameProps(pkt_size=pkt_size, **stats[n])
+        except Exception:
+            warnings.warn(f'{func}: \'Could not find stats for a section... (Frame: {n})\'')
+
+            return clip.std.SetFrameProps(
+                pkt_scene_avg_size=-1,
+                pkt_scene_max_size=-1,
+                pkt_scene_min_size=-1
+            )
+
+    stats = get_packet_scene_stats(keyframes, pkt_sizes)
+
+    return clip.std.FrameEval(partial(_set_scene_stats, clip=clip, stats=stats))
+
+
+def get_packet_scene_stats(keyframes: Keyframes, packet_sizes: list[int]) -> list[dict[str, float]]:
+    """
+    Get basic scene-based stats from packet sizes and keyframes.
+
+    :param keyframes:       Keyframes object. This is used to determine where scenes start and end.
+    :param packet_sizes:    Individual sizes for every frame.
+
+    :return:                list of dictionaries containing scene-based packet size stats.
+    """
+
+    stats = list[dict[str, float]]()
+
+    no_stats_backup = (0.0, 0.0)
+
+    try:
+        for start, end in zip(keyframes, keyframes[1:]):
+            pkt_scenes = packet_sizes[start:end]
+
+            total_pkt_size = sum(pkt_scenes)
+
+            avg_pkt_size = total_pkt_size / (len(pkt_scenes) or 1)
+            max_pkt_size = max(pkt_scenes or no_stats_backup)
+            min_pkt_size = min(pkt_scenes or no_stats_backup)
+
+            for _ in pkt_scenes:
+                stats += [dict(
+                    pkt_scene_avg_size=avg_pkt_size,
+                    pkt_scene_max_size=max_pkt_size,
+                    pkt_scene_min_size=min_pkt_size
+                )]
+    except ValueError as e:
+        raise CustomValueError('Some kind of error occurred!', get_packet_scene_stats, str(e))
+
+    return stats
+
+
+def _get_frames(sfile: SPath, func: FuncExceptT) -> list[int]:
+    if not shutil.which('ffprobe'):
+        raise DependencyNotFoundError(func, 'ffprobe', 'Could not find {package}! Make sure it\'s in your PATH!')
+
+    proc = sp.Popen(
+        [
+            'ffprobe', '-hide_banner', '-show_frames', '-show_streams', '-threads', str(core.num_threads),
+            '-loglevel', 'quiet', '-print_format', 'json', '-select_streams', 'v:0',
+            sfile
+        ],
+        stdout=sp.PIPE
+    )
+
+    with NamedTemporaryFile('a+', delete=False) as tempfile:
+        stempfile = SPath(tempfile.name)
+
+        assert proc.stdout
+
+        for line in io.TextIOWrapper(proc.stdout, 'utf-8'):
+            tempfile.write(line)
+
+    with open(stempfile) as f:
+        data = dict(json.load(f))
+
+    frames = data.get('frames', {})
+
+    if not frames:
+        raise CustomValueError(f'No frames found in file, \'{sfile}\'! Your file may be corrupted!', func)
+
+    return [int(dict(frame).get('pkt_size', -1)) for frame in frames]

--- a/vstools/functions/packets.py
+++ b/vstools/functions/packets.py
@@ -1,222 +1,159 @@
+from __future__ import annotations
+
 import io
 import json
 import shutil
-import subprocess as sp
 import warnings
-from functools import partial
+from subprocess import PIPE, Popen
 from tempfile import NamedTemporaryFile
-from typing import overload
+from typing import Self, TypedDict
 
-from stgpytools import (CustomValueError, DependencyNotFoundError, FuncExceptT,
-                        SPath, SPathLike)
+from stgpytools import CustomValueError, DependencyNotFoundError, FuncExceptT, SPath, SPathLike
 
 from .. import core, vs
-from ..functions import Keyframes
-from ..utils import get_file_from_clip
+from ..functions import Keyframes, PackageStorage
+from ..utils import get_clip_filepath
 
 __all__ = [
-    'get_packet_sizes',
-    'get_packet_scene_stats',
+    'VideoPackets',
+    'ScenePacketStats',
 ]
 
 
-@overload
-def get_packet_sizes(
-    clip: vs.VideoNode,
-    src_file: SPathLike | None = None,
-    out_file: SPathLike | None = None,
-    keyframes: Keyframes | None = None,
-    offset: int = 0,
-    return_packet_sizes: bool = False,
-    func_except: FuncExceptT | None = None
-) -> vs.VideoNode:
-    ...
+packets_storage = PackageStorage(package_name='packets')
 
 
-@overload
-def get_packet_sizes(  # type:ignore[misc]
-    clip: vs.VideoNode,
-    src_file: SPathLike | None = None,
-    out_file: SPathLike | None = None,
-    keyframes: Keyframes | None = None,
-    offset: int = 0,
-    return_packet_sizes: bool = True,
-    func_except: FuncExceptT | None = None
-) -> list[int]:
-    ...
+class ScenePacketStats(TypedDict):
+    pkt_scene_avg_size: float
+    pkt_scene_max_size: float
+    pkt_scene_min_size: float
 
 
-def get_packet_sizes(
-    clip: vs.VideoNode,
-    src_file: SPathLike | None = None,
-    out_file: SPathLike | None = None,
-    keyframes: Keyframes | None = None,
-    offset: int = 0,
-    return_packet_sizes: bool = False,
-    func_except: FuncExceptT | None = None
-) -> vs.VideoNode | list[int]:
-    """
-    A simple function to read and add frame packet sizes as frame props.
+class VideoPackets(list[int]):
 
-    "Packet sizes" are the size of individual frames. These can be used to calculate the average bitrate of a clip
-    or a scene, and to process certain frames differently depending on how much bitrate is allocated to specific
-    sections.
+    @classmethod
+    def from_video(
+        cls, src_file: SPathLike, out_file: SPathLike, offset: int = 0, *, func: FuncExceptT | None = None
+    ) -> Self:
+        func = func or cls.from_video
 
-    If `out_file` is set, the results will be written to a file. This file will be read in subsequent calls to save
-    time. This is useful when you're working with a large clip and you don't want to call ffprobe every time you
-    refresh the preview.
+        if video_packets := cls.from_file(out_file, func=func):
+            return video_packets
 
-    If a Keyframes object is passed, additional scene-based frame props will be added. These are the min, max, and
-    average packet sizes of a scene based on these Keyframes.
+        out_file = packets_storage.get_file(out_file, ext='.txt')
 
-    If a non-zero `offset` is set, the function will trim the list of packet sizes to match. Negative values will
-    instead set the packet sizes for the first `offset` frames to -1. This is intended to be used with trimmed clips.
+        if not shutil.which('ffprobe'):
+            raise DependencyNotFoundError(func, 'ffprobe', 'Could not find {package}! Make sure it\'s in your PATH!')
 
-    Dependencies:
+        proc = Popen([
+            'ffprobe', '-hide_banner', '-show_frames', '-show_streams', '-threads', str(core.num_threads),
+            '-loglevel', 'quiet', '-print_format', 'json', '-select_streams', 'v:0', src_file
+        ], stdout=PIPE)
 
-    * `ffprobe <https://ffmpeg.org/download.html>`_
+        with NamedTemporaryFile('a+') as tempfile:
+            assert proc.stdout
 
-    :param clip:                    Clip to add the properties to.
-    :param src_file:                The path to the original file that was indexed.
-                                    If None, tries to read the `idx_filepath` property from `clip`.
-                                    Will throw an error if it can't find either.
-                                    This parameter is ignored if `out_file` is set and a file can be read.
-    :param out_file:                Output file for packet sizes. If set, the results will be written to that file,
-                                    and also read from that file in subsequent calls. This saves us from having to
-                                    call ffprobe every time you refresh the preview.
-    :param keyframes:               A Keyframes object to identify scene changes. If set, scene-based metrics will
-                                    be calculated and added as frame props alongside the `pkt_size` frame prop.
-    :param offset:                  Offset to trim or duplicate the list of packet sizes. This is useful when you're
-                                    working with a trimmed clip. Should be the same value as your trim at the start
-                                    of the clip. Negative values will set the packet sizes for the first `offset`
-                                    frames to -1 instead.
-    :param return_packet_sizes:     If set to True, the function will return the packet sizes as a list of integers.
-                                    To get the scene-based stats, you will need to pass this list to the
-                                    `get_packet_scene_stats` function along with a Keyframes object.
-                                    Default: False.
-    :param func_except:             Function returned for custom error handling.
-                                    This should only be set by VS package developers.
+            for line in io.TextIOWrapper(proc.stdout, 'utf-8'):
+                tempfile.write(line)
 
-    :return:                        Input clip with `pkt_size` frame props added, with optionally scene-based packet
-                                    stats frame props added on top. if `return_packet_sizes` is set to True, it will
-                                    return the packet sizes as a list of integers instead.
-    """
+            data = dict(json.load(tempfile))
 
-    func = func_except or get_packet_sizes
+            frames = data.get('frames', {})
 
-    if out_file is not None and SPath(out_file).exists():
-        with open(out_file, 'r+') as f:
-            pkt_sizes = [int(pkt) for pkt in f.readlines()]
-    else:
-        sfile = get_file_from_clip(clip, src_file, func_except=func)
-        pkt_sizes = _get_frames(sfile, func)  # type:ignore[arg-type]
+        if not frames:
+            raise CustomValueError(f'No frames found in file, \'{src_file}\'! Your file may be corrupted!', func)
 
-    if out_file is not None and not (sout := SPath(out_file)).exists():
-        print(f'Writing packet sizes to \'{sout.absolute()}\'...')
+        pkt_sizes = [int(dict(frame).get('pkt_size', -1)) for frame in frames]
 
-        sout.parent.mkdir(parents=True, exist_ok=True)
-        sout.write_text('\n'.join([str(pkt) for pkt in pkt_sizes]), 'utf-8', newline='\n')
+        print(f'Writing packet sizes to \'{out_file.absolute()}\'...')
 
-    if offset < 0:
-        pkt_sizes = [-1] * -offset + pkt_sizes
-    elif offset > 0:
-        pkt_sizes = pkt_sizes[offset:]
+        out_file.write_text('\n'.join(map(str, pkt_sizes)), 'utf-8', newline='\n')
 
-    if return_packet_sizes:
-        return pkt_sizes
+        if offset < 0:
+            pkt_sizes = [-1] * -offset + pkt_sizes
+        elif offset > 0:
+            pkt_sizes = pkt_sizes[offset:]
 
-    def _set_sizes_props(n: int, clip: vs.VideoNode, pkt_sizes: list[int]) -> vs.VideoNode:
-        if (pkt_size := pkt_sizes[n]) < 0:
-            warnings.warn(f'{func}: \'Frame {n} bitrate could not be determined!\'')
+        return cls(pkt_sizes)
 
-        return clip.std.SetFrameProps(pkt_size=pkt_size)
+    @classmethod
+    def from_file(cls, file: SPathLike, *, func: FuncExceptT | None = None) -> Self | None:
+        if file is not None:
+            file = packets_storage.get_file(file, ext='.txt')
 
-    if not keyframes:
-        return clip.std.FrameEval(partial(_set_sizes_props, clip=clip, pkt_sizes=pkt_sizes))
+            if file.exists() and not file.stat().st_size:
+                file.unlink()
 
-    def _set_scene_stats(n: int, clip: vs.VideoNode, stats: list[dict[str, int]]) -> vs.VideoNode:
-        if (pkt_size := pkt_sizes[n]) < 0:
-            warnings.warn(f'{func}: \'Frame {n} bitrate could not be determined!\'')
+        if file is not None and file.exists():
+            with file.open('r+') as f:
+                return cls(map(int, f.readlines()))
+
+        return None
+
+    @classmethod
+    def from_clip(
+        cls, clip: vs.VideoNode,
+        out_file: SPathLike, src_file: SPathLike | None = None,
+        offset: int = 0, *, func: FuncExceptT | None = None
+    ) -> Self:
+        func = func or cls.from_video
+
+        out_file = SPath(str(out_file)).stem + f'_{clip.num_frames}_{clip.fps_num}_{clip.fps_den}'
+
+        if video_packets := cls.from_file(out_file, func=func):
+            return video_packets
+
+        src_file = get_clip_filepath(clip, src_file, func=func)
+
+        return cls.from_video(src_file, out_file, offset, func=func)
+
+    def get_scenestats(self, keyframes: Keyframes) -> list[ScenePacketStats]:
+        stats = list[ScenePacketStats]()
 
         try:
-            return clip.std.SetFrameProps(pkt_size=pkt_size, **stats[n])
-        except Exception:
-            warnings.warn(f'{func}: \'Could not find stats for a section... (Frame: {n})\'')
+            for start, end in zip(keyframes, keyframes[1:]):
+                pkt_scenes = self[start:end]
 
-            return clip.std.SetFrameProps(
-                pkt_scene_avg_size=-1,
-                pkt_scene_max_size=-1,
-                pkt_scene_min_size=-1
-            )
+                stats.append(
+                    ScenePacketStats(
+                        pkt_scene_avg_size=sum(pkt_scenes) / len(pkt_scenes),
+                        pkt_scene_max_size=max(pkt_scenes),
+                        pkt_scene_min_size=min(pkt_scenes)
+                    )
+                )
+        except ValueError as e:
+            raise CustomValueError('Some kind of error occurred!', self.get_scenestats, str(e))
 
-    stats = get_packet_scene_stats(keyframes, pkt_sizes)
+        return stats
 
-    return clip.std.FrameEval(partial(_set_scene_stats, clip=clip, stats=stats))
+    def apply_props(
+        self, clip: vs.VideoNode, keyframes: Keyframes | None = None, *, func: FuncExceptT | None = None
+    ) -> vs.VideoNode:
+        def _set_sizes_props(n: int) -> vs.VideoNode:
+            if (pkt_size := self[n]) < 0:
+                warnings.warn(f'{func}: \'Frame {n} bitrate could not be determined!\'')
 
+            return clip.std.SetFrameProps(pkt_size=pkt_size)
 
-def get_packet_scene_stats(keyframes: Keyframes, packet_sizes: list[int]) -> list[dict[str, float]]:
-    """
-    Get basic scene-based stats from packet sizes and keyframes.
+        if not keyframes:
+            return clip.std.FrameEval(_set_sizes_props)
 
-    :param keyframes:       Keyframes object. This is used to determine where scenes start and end.
-    :param packet_sizes:    Individual sizes for every frame.
+        def _set_scene_stats(n: int) -> vs.VideoNode:
+            if (pkt_size := self[n]) < 0:
+                warnings.warn(f'{func}: \'Frame {n} bitrate could not be determined!\'')
 
-    :return:                list of dictionaries containing scene-based packet size stats.
-    """
+            try:
+                return clip.std.SetFrameProps(pkt_size=pkt_size, **scenestats[keyframes.scenes.indices[n]])
+            except Exception:
+                warnings.warn(f'{func}: \'Could not find stats for a section... (Frame: {n})\'')
 
-    stats = list[dict[str, float]]()
+                return clip.std.SetFrameProps(
+                    pkt_size=-1,
+                    pkt_scene_avg_size=-1,
+                    pkt_scene_max_size=-1,
+                    pkt_scene_min_size=-1
+                )
 
-    no_stats_backup = (0.0, 0.0)
+        scenestats = self.get_scenestats(keyframes)
 
-    try:
-        for start, end in zip(keyframes, keyframes[1:]):
-            pkt_scenes = packet_sizes[start:end]
-
-            total_pkt_size = sum(pkt_scenes)
-
-            avg_pkt_size = total_pkt_size / (len(pkt_scenes) or 1)
-            max_pkt_size = max(pkt_scenes or no_stats_backup)
-            min_pkt_size = min(pkt_scenes or no_stats_backup)
-
-            for _ in pkt_scenes:
-                stats += [dict(
-                    pkt_scene_avg_size=avg_pkt_size,
-                    pkt_scene_max_size=max_pkt_size,
-                    pkt_scene_min_size=min_pkt_size
-                )]
-    except ValueError as e:
-        raise CustomValueError('Some kind of error occurred!', get_packet_scene_stats, str(e))
-
-    return stats
-
-
-def _get_frames(sfile: SPath, func: FuncExceptT) -> list[int]:
-    if not shutil.which('ffprobe'):
-        raise DependencyNotFoundError(func, 'ffprobe', 'Could not find {package}! Make sure it\'s in your PATH!')
-
-    proc = sp.Popen(
-        [
-            'ffprobe', '-hide_banner', '-show_frames', '-show_streams', '-threads', str(core.num_threads),
-            '-loglevel', 'quiet', '-print_format', 'json', '-select_streams', 'v:0',
-            sfile
-        ],
-        stdout=sp.PIPE
-    )
-
-    with NamedTemporaryFile('a+', delete=False) as tempfile:
-        stempfile = SPath(tempfile.name)
-
-        assert proc.stdout
-
-        for line in io.TextIOWrapper(proc.stdout, 'utf-8'):
-            tempfile.write(line)
-
-    with open(stempfile) as f:
-        data = dict(json.load(f))
-
-    frames = data.get('frames', {})
-
-    if not frames:
-        raise CustomValueError(f'No frames found in file, \'{sfile}\'! Your file may be corrupted!', func)
-
-    return [int(dict(frame).get('pkt_size', -1)) for frame in frames]
+        return clip.std.FrameEval(_set_scene_stats)

--- a/vstools/utils/props.py
+++ b/vstools/utils/props.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Callable, TypeVar, overload
+from typing import Any, Callable, Literal, TypeVar, overload
 
 import vapoursynth as vs
-from stgpytools import MISSING, FuncExceptT, MissingT, SupportsString
+from stgpytools import MISSING, FileWasNotFoundError, FuncExceptT, MissingT, SPath, SPathLike, SupportsString
 
 from ..enums import PropEnum
 from ..exceptions import FramePropError
@@ -11,7 +11,8 @@ from ..types import BoundVSMapValue, HoldsPropValueT
 
 __all__ = [
     'get_prop',
-    'merge_clip_props'
+    'merge_clip_props',
+    'get_file_from_clip'
 ]
 
 DT = TypeVar('DT')
@@ -150,3 +151,66 @@ def merge_clip_props(*clips: vs.VideoNode, main_idx: int = 0) -> vs.VideoNode:
         return fdst
 
     return clips[0].std.ModifyFrame(clips, _merge_props)
+
+
+@overload
+def get_file_from_clip(
+    clip: vs.VideoNode, fallback: SPathLike | None = ...,
+    prop: str = ..., strict: bool = True,
+    func_except: FuncExceptT | None = ...
+) -> SPath:
+    ...
+
+
+@overload
+def get_file_from_clip(  # type:ignore[misc]
+    clip: vs.VideoNode, fallback: SPathLike | None = ...,
+    prop: str = ..., strict: bool = False,
+    func_except: FuncExceptT | None = ...
+) -> SPath | Literal[False]:
+    ...
+
+
+def get_file_from_clip(
+    clip: vs.VideoNode, fallback: SPathLike | None = None,
+    prop: str = "idx_filepath", strict: bool = False,
+    func_except: FuncExceptT | None = None
+) -> SPath | Literal[False]:
+    """
+    Helper function to get the file path from a clip.
+
+    This function also checks to ensure the file exists,
+    and throws an error if it doesn't.
+
+    :param clip:                    The clip to get the file path from.
+    :param fallback:                Fallback file path to use if the `prop` is not found.
+    :param prop:                    The property to get the file path from.
+                                    Default: "idx_filepath" (used by vs-source classes).
+    :param strict:                  If True, will raise an error if the `prop` is not found.
+                                    This makes it so the function will NEVER return False.
+                                    Default: False.
+    :param func_except:             Function returned for custom error handling.
+                                    This should only be set by VS package developers.
+
+    :raises FileWasNotFoundError:   The file path was not found.
+    :raises FramePropError:         The property was not found in the clip.
+    """
+
+    func = func_except or get_file_from_clip
+
+    if fallback is not None and not (fallback_path := SPath(fallback)).exists() and strict:
+        raise FileWasNotFoundError('Fallback file not found!', func, fallback_path.absolute())
+
+    if not (path := get_prop(clip, prop, str, default=MISSING if strict else False, func=func)):
+        return fallback_path or False
+
+    if not (spath := SPath(str(path))).exists() and not fallback:
+        raise FileWasNotFoundError('File not found!', func, spath.absolute())
+
+    if spath.exists():
+        return spath
+
+    if fallback is not None and fallback_path.exists():
+        return fallback_path
+
+    raise FileWasNotFoundError('File not found!', func, spath.absolute())


### PR DESCRIPTION
Lightly modified lvsfunc code. May see some use for specific processes where packet size (i.e. bitrate-per-frame/scene) metrics are useful, such as selectively picking frames/scenes between two sources.