### PR TITLE
FunctionUtil: Add specific bitrates support

### DIFF
--- a/vstools/functions/funcs.py
+++ b/vstools/functions/funcs.py
@@ -82,7 +82,7 @@ class FunctionUtil(cachedproperty.baseclass, list[int]):
         assert check_variable(clip, func)
 
         if color_family is not None:
-            color_family = [get_color_family(c) for c in to_arr(color_family)]  # type: ignore
+            color_family = [get_color_family(c) for c in to_arr(color_family)]
 
             if strict:
                 InvalidColorFamilyError.check(clip, color_family, func)
@@ -114,7 +114,9 @@ class FunctionUtil(cachedproperty.baseclass, list[int]):
         if isinstance(self.bitdepth, range) and self.clip.format.bits_per_sample not in self.bitdepth:
             clip = depth(self.clip, self.bitdepth.stop)
         elif isinstance(self.bitdepth, set) and self.clip.format.bits_per_sample not in self.bitdepth:
-            clip = depth(self.clip, max(self.bitdepth))
+            from .. import get_depth
+
+            clip = depth(self.clip, min(bits for bits in self.bitdepth if bits >= get_depth(self.clip)))
         elif isinstance(self.bitdepth, int):
             clip = depth(self.clip, self.bitdepth)
         else:
@@ -149,6 +151,7 @@ class FunctionUtil(cachedproperty.baseclass, list[int]):
 
         if self != [0] or self.norm_clip.format.num_planes == 1:
             return []
+
         return [plane(self.norm_clip, i) for i in (1, 2)]
 
     @cachedproperty


### PR DESCRIPTION
This is most useful for wrappers around plugins that require specific bitdepths, not a range of bitdepths inbetween two depths.

```py
from vstools import core, FunctionUtil, vs

b = core.std.BlankClip(None, 1920, 1080, vs.YUV420P8)

f1 = FunctionUtil(b, __file__, bitdepth={8, 16})
f2 = FunctionUtil(b, __file__, bitdepth={16, 32})

print(f"{f1.work_clip.format=}")
print(f"{f2.work_clip.format=}")
```

```py
$ python test.py
f1.work_clip.format=<vapoursynth.VideoFormat object at 0x000001B299EEBCA0 id=805830913, name=YUV420P8, color_family=YUV, sample_type=INTEGER, bits_per_sample=8, bytes_per_sample=1, num_planes=3, subsampling_w=1, subsampling_h=1>
f2.work_clip.format=<vapoursynth.VideoFormat object at 0x000001B299EEBD00 id=824180993, name=YUV420PS, color_family=YUV, sample_type=FLOAT, bits_per_sample=32, bytes_per_sample=4, num_planes=3, subsampling_w=1, subsampling_h=1>
```