### PR TITLE
Plugin/Package Dependency Registry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setuptools.setup(
     python_requires='>=3.12',
     packages=[
         package_name,
+        f'{package_name}.dependencies',
         f'{package_name}.enums',
         f'{package_name}.exceptions',
         f'{package_name}.functions',

--- a/vstools/__init__.py
+++ b/vstools/__init__.py
@@ -1,3 +1,4 @@
+from .dependencies import *  # noqa: F401, F403
 from .enums import *  # noqa: F401, F403
 from .exceptions import *  # noqa: F401, F403
 from .functions import *  # noqa: F401, F403

--- a/vstools/dependencies/__init__.py
+++ b/vstools/dependencies/__init__.py
@@ -1,0 +1,1 @@
+from .registry import *  # noqa: F401, F403

--- a/vstools/dependencies/__init__.py
+++ b/vstools/dependencies/__init__.py
@@ -1,1 +1,2 @@
+from .enums import *  # noqa: F401, F403
 from .registry import *  # noqa: F401, F403

--- a/vstools/dependencies/enums.py
+++ b/vstools/dependencies/enums.py
@@ -1,0 +1,18 @@
+from stgpytools import CustomIntEnum
+
+__all__ = [
+    'InstallModeEnum'
+]
+
+
+class InstallModeEnum(CustomIntEnum):
+    """Enumeration for different installation modes of dependencies."""
+
+    AUTO = 0
+    """Automatically install missing dependencies without prompting."""
+
+    PROMPT = 1
+    """Prompt the user before installing missing dependencies."""
+
+    MANUAL = 2
+    """Do not install dependencies automatically; user must install manually."""

--- a/vstools/dependencies/registry.py
+++ b/vstools/dependencies/registry.py
@@ -83,23 +83,25 @@ class PackageDependencyRegistry:
         self,
         dependency: str,
         functions: Iterable[str] | None = None,
-        url: str | None = None,
         parent_package: str | None = None,
+        *,
+        url: str | None = None,
         optional: bool = False,
     ) -> None:
         """
         Register a plugin for a package.
 
-        :param dependency:      The name of the plugin to depend on.
-        :param functions:       A list of functions used by the plugin.
-                                A check is performed to ensure the installed plugin has these functions.
-        :param url:             The url to the plugin's download page. Defaults to None.
-        :param parent_package:  The name of the package that depends on this plugin.
-        :param optional:        Whether the plugin is optional. Defaults to False.
+        :param dependency:              The name of the plugin to depend on.
+        :param functions:               A list of functions used by the plugin.
+                                        A check is performed to ensure the installed plugin has these functions.
+        :param parent_package:          The name of the package that depends on this plugin.
+        :param url:                     The url to the plugin's download page. Defaults to None.
+        :param optional:                Whether the plugin is optional. Defaults to False.
         """
 
         if not parent_package:
             from ..utils.package import get_calling_package
+
             parent_package = get_calling_package()
 
         if not dependency:
@@ -123,21 +125,23 @@ class PackageDependencyRegistry:
     def add_package(
         self,
         dependency: str,
-        parent_package: str | None = None,
-        version: str | None = None,
         functions: str | list[str] | None = None,
+        parent_package: str | None = None,
+        *,
+        version: str | None = None,
         optional: bool = False,
         url: str | None = None,
     ) -> None:
         """
         Register a package dependency.
 
-        :param dependency:      The name of the dependency to register.
-        :param parent_package:  The name of the package that depends on this dependency.
-        :param version:         The required version of the dependency. Defaults to None.
-        :param functions:       A function or list of functions to check for in the dependency. Defaults to None.
-        :param optional:        Whether the dependency is optional. Defaults to False.
-        :param url:             The url to the dependency's download page. Defaults to None.
+        :param dependency:              The name of the dependency to register.
+        :param functions:               A function or list of functions to check for in the dependency.
+                                        Defaults to None.
+        :param parent_package:          The name of the package that depends on this dependency.
+        :param version:                 The required version of the dependency. Defaults to None.
+        :param optional:                Whether the dependency is optional. Defaults to False.
+        :param url:                     The url to the dependency's download page. Defaults to None.
         """
 
         if not parent_package:

--- a/vstools/dependencies/registry.py
+++ b/vstools/dependencies/registry.py
@@ -83,6 +83,7 @@ class PackageDependencyRegistry:
 
     def __post_init__(self) -> None:
         self.vsrepo_available = importlib.util.find_spec('vsrepo') is not None
+        # TODO: Ensure vspreview's setting is set here if possible
 
     def set_install_mode(self, install_mode: InstallModeEnum) -> None:
         """
@@ -144,7 +145,8 @@ class PackageDependencyRegistry:
         plugin_info = self.plugin_registry[parent_package].get(dependency, PluginInfo())
 
         if functions:
-            plugin_info.required_functions.extend(list(set(functions) - set(plugin_info.required_functions)))
+            new_functions = [functions] if isinstance(functions, str) else functions
+            plugin_info.required_functions.extend(list(set(new_functions) - set(plugin_info.required_functions)))
 
         if url:
             plugin_info.url = url

--- a/vstools/dependencies/registry.py
+++ b/vstools/dependencies/registry.py
@@ -1,0 +1,171 @@
+from dataclasses import dataclass, field
+from typing import Iterable
+
+import importlib.util
+
+__all__: list[str] = [
+    'PackageDependencyRegistry',
+
+    'dependency_registry',
+
+    'PluginInfo',
+    'PackageInfo',
+]
+
+
+@dataclass
+class PluginInfo:
+    """Information about a plugin."""
+
+    required_functions: list[str] = field(default_factory=list)
+    """A list of function names that must be provided by the plugin."""
+
+    url: str | None = None
+    """The URL where the plugin can be downloaded or found, if available."""
+
+    optional: bool = False
+    """Indicates whether the plugin is optional or required."""
+
+
+@dataclass
+class PackageInfo:
+    """Information about a package."""
+
+    required_functions: list[str] = field(default_factory=list)
+    """A list of function names that must be provided by the package."""
+
+    version: str | None = None
+    """The version of the package, if specified."""
+
+    url: str | None = None
+    """The URL where the package can be downloaded or found, if available."""
+
+    optional: bool = False
+    """Indicates whether the package is optional or required."""
+
+
+@dataclass
+class PackageDependencyRegistry:
+    """A registry for managing package dependencies and plugins."""
+
+    plugin_registry: dict[str, dict[str, PluginInfo]] = field(default_factory=dict)
+    """
+    A registry of plugins and their metadata.
+
+    Structure:
+    {
+        package_name (str): {
+            plugin_name (str): PluginInfo,
+            #  Additional plugins...
+        },
+        #  Additional packages...
+    }
+    """
+
+    package_registry: dict[str, dict[str, PackageInfo]] = field(default_factory=dict)
+    """
+    A registry of packages and their metadata.
+
+    Structure:
+    {
+        package_name (str): PackageInfo,
+        #  Additional packages...
+    }
+    """
+
+    vsrepo_available: bool = field(init=False)
+    """A flag indicating whether the 'vsrepo' module is available."""
+
+    def __post_init__(self) -> None:
+        self.vsrepo_available = importlib.util.find_spec('vsrepo') is not None
+
+    def add_plugin(
+        self,
+        dependency: str,
+        functions: Iterable[str] | None = None,
+        url: str | None = None,
+        parent_package: str | None = None,
+        optional: bool = False,
+    ) -> None:
+        """
+        Register a plugin for a package.
+
+        :param dependency:      The name of the plugin to depend on.
+        :param functions:       A list of functions used by the plugin.
+                                A check is performed to ensure the installed plugin has these functions.
+        :param url:             The url to the plugin's download page. Defaults to None.
+        :param parent_package:  The name of the package that depends on this plugin.
+        :param optional:        Whether the plugin is optional. Defaults to False.
+        """
+
+        if not parent_package:
+            from ..utils.package import get_calling_package
+            parent_package = get_calling_package()
+
+        if not dependency:
+            return
+
+        if parent_package not in self.plugin_registry:
+            self.plugin_registry[parent_package] = {}
+
+        plugin_info = self.plugin_registry[parent_package].get(dependency, PluginInfo())
+
+        if functions:
+            plugin_info.required_functions.extend(list(set(functions) - set(plugin_info.required_functions)))
+
+        if url:
+            plugin_info.url = url
+
+        plugin_info.optional = optional
+
+        self.plugin_registry[parent_package][dependency] = plugin_info
+
+    def add_package(
+        self,
+        dependency: str,
+        parent_package: str | None = None,
+        version: str | None = None,
+        functions: str | list[str] | None = None,
+        optional: bool = False,
+        url: str | None = None,
+    ) -> None:
+        """
+        Register a package dependency.
+
+        :param dependency:      The name of the dependency to register.
+        :param parent_package:  The name of the package that depends on this dependency.
+        :param version:         The required version of the dependency. Defaults to None.
+        :param functions:       A function or list of functions to check for in the dependency. Defaults to None.
+        :param optional:        Whether the dependency is optional. Defaults to False.
+        :param url:             The url to the dependency's download page. Defaults to None.
+        """
+
+        if not parent_package:
+            from ..utils.package import get_calling_package
+
+            parent_package = get_calling_package()
+
+        if not dependency:
+            return
+
+        if parent_package not in self.package_registry:
+            self.package_registry[parent_package] = {}
+
+        package_info = self.package_registry[parent_package].get(dependency, PackageInfo())
+
+        if functions:
+            new_functions = [functions] if isinstance(functions, str) else functions
+            package_info.required_functions.extend(list(set(new_functions) - set(package_info.required_functions)))
+
+        if url:
+            package_info.url = url
+
+        if version:
+            package_info.version = version
+
+        package_info.optional = optional
+
+        self.package_registry[parent_package][dependency] = package_info
+
+
+dependency_registry = PackageDependencyRegistry()

--- a/vstools/exceptions/__init__.py
+++ b/vstools/exceptions/__init__.py
@@ -1,5 +1,6 @@
 from .base import *  # noqa: F401, F403
 from .color import *  # noqa: F401, F403
+from .dependencies import *  # noqa: F401, F403
 from .enum import *  # noqa: F401, F403
 from .file import *  # noqa: F401, F403
 from .generic import *  # noqa: F401, F403

--- a/vstools/exceptions/dependencies.py
+++ b/vstools/exceptions/dependencies.py
@@ -160,7 +160,7 @@ class PluginNotFoundError(DependencyRegistryError):
             if plugin_data and plugin_data.optional:
                 if not hasattr(core, plugin):
                     warnings.warn(
-                        f'Optional plugin \'{plugin}\' for \'{parent_package}\' is not installed.', ImportWarning
+                        f'Optional plugin \'{plugin}\' for \'{parent_package}\' is not installed.', UserWarning
                     )
 
                 continue
@@ -253,7 +253,7 @@ class PackageNotFoundError(DependencyRegistryError):
             if package_data.optional:
                 if importlib.util.find_spec(pkg) is None:
                     warnings.warn(
-                        f'Optional package \'{pkg}\' for \'{parent_package}\' is not installed.', ImportWarning
+                        f'Optional package \'{pkg}\' for \'{parent_package}\' is not installed.', UserWarning
                     )
 
                 continue

--- a/vstools/exceptions/dependencies.py
+++ b/vstools/exceptions/dependencies.py
@@ -1,0 +1,267 @@
+from typing import Any
+
+from stgpytools import CustomValueError, FuncExceptT
+
+from ..dependencies.registry import dependency_registry, PackageInfo, PluginInfo
+
+__all__: list[str] = [
+    'DependencyRegistryError',
+    'PluginNotFoundError',
+    'PackageNotFoundError',
+]
+
+
+class DependencyRegistryError(CustomValueError):
+    """Base class for dependency registry errors."""
+
+    @classmethod
+    def _get_package(cls, parent_package: str | None = None) -> str:
+        """
+        Get the package name, either from the provided value or by auto-detection.
+
+        :param parent_package: The package name (optional).
+        :return: The package name.
+        """
+
+        if parent_package is not None:
+            return parent_package
+
+        from ..utils.package import get_calling_package
+
+        return get_calling_package(3)
+
+    @staticmethod
+    def _check_vsrepo(plugin: str) -> bool:
+        """
+        Check if the plugin is available in VSRepo and prompt for installation if not installed.
+
+        :param plugin:      The plugin to check.
+
+        :return:            True if the plugin was installed, False otherwise.
+        """
+
+        if not dependency_registry.vsrepo_available:
+            return False
+
+        import subprocess
+
+        def run_vsrepo(args: Any) -> Any:
+            try:
+                return subprocess.run(["vsrepo"] + args, capture_output=True, text=True, check=True)
+            except subprocess.CalledProcessError as e:
+                return e
+            except FileNotFoundError:
+                print("Failed to run vsrepo: command not found")
+
+        if run_vsrepo(["installed", plugin]).returncode == 0:
+            return True
+
+        result = run_vsrepo(["available", plugin])
+
+        if result.returncode != 0 or "not found" in result.stdout.lower():
+            return False
+
+        print(f"Plugin '{plugin}' is available in VSRepo but not installed.")
+
+        user_input = input(f"Do you want to install \'{plugin}\'? (y/n): ").lower().strip()
+
+        if not user_input or user_input != 'y':
+            print(f"Installation of \'{plugin}\' cancelled by user.")
+
+            return False
+
+        result = run_vsrepo(["install", plugin])
+
+        if result and result.returncode == 0:
+            print(f"Successfully installed \'{plugin}\'")
+            return True
+
+        print(f"Failed to install \'{plugin}\'")
+        return False
+
+    @classmethod
+    def _get_missing_functions(cls, plugin_functions: list[str], plugin: str) -> list[str]:
+        from vstools import core
+
+        plugin_obj = getattr(core, plugin)
+
+        return [
+            f for f in plugin_functions if not hasattr(plugin_obj, f)
+            and not hasattr(getattr(plugin_obj, f, None), '__call__')
+        ]
+
+    @classmethod
+    def _format_message(
+        cls, base_msg: str, missing: list[str],
+        version: str | None = None, url: str | None = None,
+        prompt_update: bool = False
+    ) -> str:
+        msg = f"{base_msg}: [{', '.join(missing)}]. "
+
+        if version:
+            msg += f"Required version: {version}. "
+
+        if url:
+            msg += f"Download URL: {url}"
+
+        if prompt_update:
+            msg += "You may need to update!"
+
+        return msg
+
+
+class PluginNotFoundError(DependencyRegistryError):
+    """Raised when a required plugin is not found in the registry."""
+
+    def __init__(
+        self, func: FuncExceptT, parent_package: str, plugin: str,
+        message: str = 'Plugin \'{plugin}\' not found for package \'{parent_package}\'',
+        **kwargs: Any
+    ) -> None:
+        super().__init__(message, func, parent_package=parent_package, plugin=plugin, **kwargs)
+
+    @classmethod
+    def check(
+        cls, func: FuncExceptT, plugins: str | list[str] | None = None,
+        message: str | None = None, parent_package: str | None = None, **kwargs: Any
+    ) -> None:
+        """
+        Check if plugin(s) exist in the registry and raise an error if they don't.
+
+        :param func:                    The function to check.
+        :param plugins:                 The plugin or list of plugins to check for.
+                                        If None, check all plugins in the caller package's namespace.
+        :param message:                 Optional custom error message.
+        :param parent_package:          The package name to check for. If None, check all packages.
+        :param kwargs:                  Additional keyword arguments.
+
+        :raises PluginNotFoundError:    If any plugin is not found in the registry.
+        """
+
+        from vstools import core
+
+        parent_package = cls._get_package(parent_package)
+
+        if plugins is not None:
+            plugins_to_check = [plugins] if isinstance(plugins, str) else plugins
+        else:
+            plugins_to_check = list(dependency_registry.plugin_registry.get(parent_package, {}).keys())
+
+        missing_plugins = []
+        missing_functions = {}
+
+        for plugin in plugins_to_check:
+            if not hasattr(core, plugin):
+                if cls._check_vsrepo(plugin):
+                    continue
+
+                missing_plugins.append(plugin)
+                continue
+
+            plugin_data: PluginInfo = dependency_registry.plugin_registry[parent_package][plugin]
+
+            if not plugin_data.required_functions:
+                continue
+
+            if missing_funcs := cls._get_missing_functions(plugin_data.required_functions, plugin):
+                missing_functions[plugin] = missing_funcs
+
+        if missing_plugins or missing_functions:
+            error_messages = []
+
+            if missing_plugins:
+                error_messages.append(
+                    f"Plugin(s) not found for package '{parent_package}': {', '.join(missing_plugins)}"
+                )
+
+            for plugin, funcs in missing_functions.items():
+                plugin_info: PluginInfo = dependency_registry.plugin_registry[parent_package][plugin]
+
+                error_messages.append(cls._format_message(
+                    f"Plugin '{plugin}' for package '{parent_package}' is missing the following function(s)",
+                    missing=funcs, url=plugin_info.url, prompt_update=True
+                ))
+
+            raise cls(
+                func, parent_package,
+                ', '.join(missing_plugins + list(missing_functions.keys())),
+                message or '\n'.join(error_messages),
+                **kwargs
+            )
+
+
+class PackageNotFoundError(DependencyRegistryError):
+    """Raised when a required package is not found in the registry."""
+
+    def __init__(
+        self, func: FuncExceptT, parent_package: str,
+        package: str | None = None, message: str | None = None,
+        **kwargs: Any
+    ) -> None:
+        super().__init__(
+            message or f"Package '{package or parent_package}' not found in the registry",
+            func, parent_package=parent_package, **kwargs
+        )
+
+    @classmethod
+    def check(
+        cls, func: FuncExceptT, packages: str | list[str] | None = None,
+        message: str | None = None, parent_package: str | None = None, **kwargs: Any
+    ) -> None:
+        """
+        Check if package(s) exist in the registry and raise an error if they don't.
+
+        :param func:                    The function to check.
+        :param packages:                The package or list of packages to check for.
+                                        If None, check all packages in the caller package's namespace.
+        :param message:                 Optional custom error message.
+        :param parent_package:          The package name to check for. If None, check all packages.
+        :param kwargs:                  Additional keyword arguments.
+
+        :raises PackageNotFoundError:   If any package is not found in the registry.
+        """
+
+        parent_package = cls._get_package(parent_package)
+        if packages is not None:
+            packages_to_check = [packages] if isinstance(packages, str) else packages
+        else:
+            packages_to_check = list(dependency_registry.package_registry.get(parent_package, {}).keys())
+
+        missing_packages = []
+        missing_functions = {}
+
+        for pkg in packages_to_check:
+            if pkg not in dependency_registry.package_registry.get(parent_package, {}):
+                missing_packages.append(pkg)
+                continue
+
+            package_info: PackageInfo = dependency_registry.package_registry[parent_package][pkg]
+
+            if not package_info.required_functions:
+                continue
+
+            if missing_funcs := cls._get_missing_functions(package_info.required_functions, pkg):
+                missing_functions[pkg] = missing_funcs
+
+        if missing_packages or missing_functions:
+            error_messages = []
+
+            if missing_packages:
+                error_messages.append(
+                    f"Package(s) not found for package '{parent_package}': {', '.join(missing_packages)}"
+                )
+
+            for pkg, funcs in missing_functions.items():
+                pkg_info = dependency_registry.package_registry[parent_package][pkg]
+
+                error_messages.append(cls._format_message(
+                    f"Package '{pkg}' for package '{parent_package}' is missing the following function(s)",
+                    missing=funcs, url=pkg_info.url, version=pkg_info.version
+                ))
+
+            raise cls(
+                func, parent_package,
+                package=', '.join(missing_packages + list(missing_functions.keys())),
+                message=message or '\n'.join(error_messages),
+                **kwargs
+            )

--- a/vstools/functions/check.py
+++ b/vstools/functions/check.py
@@ -194,6 +194,7 @@ def check_correct_subsampling(
 
     :raises InvalidSubsamplingError:    The clip has invalid subsampling.
     """
+
     from ..exceptions import InvalidSubsamplingError
 
     if clip.format:
@@ -209,18 +210,18 @@ def check_correct_subsampling(
 
 
 def check_dependencies(
-    func: FuncExceptT, message: str | None = None, parent_package: str | None = None, **kwargs: Any
-) -> None:
+    parent_package: str | None = None, func: FuncExceptT | None = None, **kwargs: Any
+) -> bool:
     """
     Check for both plugin and package dependencies.
 
-    :param func:                    The function to check.
-    :param message:                 Custom error message (optional).
-    :param parent_package:          The package name (optional, will be auto-detected if not provided).
-    :param kwargs:                  Additional keyword arguments.
+    :param parent_package:              The name of the parent package. If None, automatically determine.
+    :param func:                        Function returned for custom error handling.
+                                        This should only be set by VS package developers.
+    :param kwargs:                      Additional keyword arguments to pass on to the `check` methods.
 
-    :raises PluginNotFoundError:    If a required plugin is not found.
-    :raises PackageNotFoundError:   If a required package is not found.
+    :raises PluginNotFoundError:        If a required plugin is not found.
+    :raises PackageNotFoundError:       If a required package is not found.
     """
 
     func = func or check_dependencies
@@ -230,15 +231,15 @@ def check_dependencies(
 
         parent_package = get_calling_package(2)
 
-    errors = []
+    errors = list[DependencyRegistryError]()
 
     try:
-        PluginNotFoundError.check(func, None, message, parent_package, **kwargs)
+        PluginNotFoundError.check(func, None, None, parent_package, **kwargs)
     except PluginNotFoundError as e:
         errors.append(e)
 
     try:
-        PackageNotFoundError.check(func, None, message, parent_package, **kwargs)
+        PackageNotFoundError.check(func, None, None, parent_package, **kwargs)
     except PackageNotFoundError as e:
         errors.append(e)
 
@@ -247,3 +248,5 @@ def check_dependencies(
             raise errors[0]
 
         raise DependencyRegistryError(func, '\n'.join(str(e) for e in errors))
+
+    return True

--- a/vstools/utils/__init__.py
+++ b/vstools/utils/__init__.py
@@ -10,6 +10,7 @@ from .math import *  # noqa: F401, F403
 from .mime import *  # noqa: F401, F403
 from .misc import *  # noqa: F401, F403
 from .other import *  # noqa: F401, F403
+from .package import *  # noqa: F401, F403
 from .props import *  # noqa: F401, F403
 from .ranges import *  # noqa: F401, F403
 from .scale import *  # noqa: F401, F403

--- a/vstools/utils/package.py
+++ b/vstools/utils/package.py
@@ -1,56 +1,21 @@
 import inspect
-from typing import ParamSpec, TypeVar
 
 from stgpytools import SPath
 
 __all__: list[str] = [
-    'get_calling_package_name',
-
     'get_calling_package'
 ]
-
-
-P = ParamSpec('P')
-R = TypeVar('R')
-
-
-def get_calling_package_name() -> str:
-    """
-    Get the name of the package to which the calling function belongs.
-
-    :param depth:   The depth in the call stack to look for the package name. Default is 1.
-
-    :return:        The name of the package containing the calling function.
-    """
-
-    frame = inspect.currentframe()
-
-    try:
-        if frame is None:
-            return "unknown"
-
-        module = inspect.getmodule(frame)
-
-        if module is None:
-            return "unknown"
-
-        package = module.__package__
-
-        if package is None:
-            return module.__name__.split('.')[0]
-
-        return package.split('.')[0]
-    finally:
-        del frame
 
 
 def get_calling_package(depth: int = 2) -> str:
     """
     Get the name of the package from which this function is called.
 
+    If the name is "__main__", use the caller's filename instead.
+
     :param depth:       The number of frames to go back in the call stack. Default is 2.
 
-    :return:            The name of the calling package.
+    :return:            The name of the calling package or file.
     """
 
     stack = inspect.stack()

--- a/vstools/utils/package.py
+++ b/vstools/utils/package.py
@@ -1,0 +1,70 @@
+import inspect
+from typing import ParamSpec, TypeVar
+
+from stgpytools import SPath
+
+__all__: list[str] = [
+    'get_calling_package_name',
+
+    'get_calling_package'
+]
+
+
+P = ParamSpec('P')
+R = TypeVar('R')
+
+
+def get_calling_package_name() -> str:
+    """
+    Get the name of the package to which the calling function belongs.
+
+    :param depth:   The depth in the call stack to look for the package name. Default is 1.
+
+    :return:        The name of the package containing the calling function.
+    """
+
+    frame = inspect.currentframe()
+
+    try:
+        if frame is None:
+            return "unknown"
+
+        module = inspect.getmodule(frame)
+
+        if module is None:
+            return "unknown"
+
+        package = module.__package__
+
+        if package is None:
+            return module.__name__.split('.')[0]
+
+        return package.split('.')[0]
+    finally:
+        del frame
+
+
+def get_calling_package(depth: int = 2) -> str:
+    """
+    Get the name of the package from which this function is called.
+
+    :param depth:       The number of frames to go back in the call stack. Default is 2.
+
+    :return:            The name of the calling package.
+    """
+
+    stack = inspect.stack()
+
+    if len(stack) <= depth:
+        return 'unknown'
+
+    frame_info = stack[depth]
+    module = inspect.getmodule(frame_info.frame)
+
+    if not module:
+        return 'unknown'
+
+    if module.__name__ == '__main__':
+        return SPath(frame_info.filename).name
+
+    return module.__name__.split('.')[0]


### PR DESCRIPTION
Taking feedback from #124 into account, this now implements a dependency registry object instead.

This allows for the following functionality:

- Different packages can all add to the registry
- New function and exceptions to check if the given plugins, or all plugins in the given parent namespace is available.
- Automatically assume parent namespace if none is provided.
- Prompt the user to install if vsrepo is available on their system and the given plugin/package is found in there.

### Regular usage example

```py
dependency_registry.add_plugin('akarin2', ["Expr"], optional=False)
dependency_registry.add_plugin('akarin', ["Expr"], "testfunc")
dependency_registry.add_plugin('Eedi3', ["Expr"], "lvsfunc", optional=True)
dependency_registry.add_plugin('assrender', ["Expr"], "havsfunc")
dependency_registry.add_plugin('Nnedi3', ["Expr"], "lvsfunc", optional=True)
dependency_registry.add_plugin('Nnedi3', ["Expr"], "xvsfunc")

pprint(dependency_registry, width=180)
print()

check_dependencies(None, func="some_random_func")
check_dependencies("lvsfunc", func="some_random_func")
```

Output:

```py
$ python test.py
PackageDependencyRegistry(plugin_registry={'havsfunc': {'assrender': PluginInfo(required_functions=['Expr'], url=None, optional=False)},
                                           'lvsfunc': {'Eedi3': PluginInfo(required_functions=['Expr'], url=None, optional=True),
                                                       'Nnedi3': PluginInfo(required_functions=['Expr'], url=None, optional=True)},
                                           'test.py': {'akarin2': PluginInfo(required_functions=['Expr'], url=None, optional=False)},
                                           'testfunc': {'akarin': PluginInfo(required_functions=['Expr'], url=None, optional=False)},
                                           'xvsfunc': {'Nnedi3': PluginInfo(required_functions=['Expr'], url=None, optional=False)}},
                          package_registry={},
                          vsrepo_available=True,
                          install_mode=<InstallModeEnum.PROMPT: 1>)

Traceback (most recent call last):
  File "C:\Users\light\GitHub\Jaded-Encoding-Thaumaturgy\vs-tools\test.py", line 19, in <module>
    check_dependencies(None, func="some_random_func")
  File "C:\Users\light\GitHub\Jaded-Encoding-Thaumaturgy\vs-tools\vstools\functions\check.py", line 248, in check_dependencies
    raise errors[0]
  File "C:\Users\light\GitHub\Jaded-Encoding-Thaumaturgy\vs-tools\vstools\functions\check.py", line 237, in check_dependencies
    PluginNotFoundError.check(func, None, None, parent_package, **kwargs)
  File "C:\Users\light\GitHub\Jaded-Encoding-Thaumaturgy\vs-tools\vstools\exceptions\dependencies.py", line 253, in check
    raise cls(
PluginNotFoundError: (some_random_func) Plugin(s) not found for package 'test.py': akarin2
```

### Checking only lvsfunc deps and check the optional deps

```py
# check_dependencies(None, func="some_random_func")
check_dependencies("lvsfunc", func="some_random_func")
```

Output:

```py
$ python test.py
PackageDependencyRegistry(plugin_registry={'havsfunc': {'assrender': PluginInfo(required_functions=['Expr'], url=None, optional=False)},
                                           'lvsfunc': {'Eedi3': PluginInfo(required_functions=['Expr'], url=None, optional=True),
                                                       'Nnedi3': PluginInfo(required_functions=['Expr'], url=None, optional=True)},
                                           'test.py': {'akarin2': PluginInfo(required_functions=['Expr'], url=None, optional=False)},
                                           'testfunc': {'akarin': PluginInfo(required_functions=['Expr'], url=None, optional=False)},
                                           'xvsfunc': {'Nnedi3': PluginInfo(required_functions=['Expr'], url=None, optional=False)}},
                          package_registry={},
                          vsrepo_available=True,
                          install_mode=<InstallModeEnum.PROMPT: 1>)

C:\Users\light\GitHub\Jaded-Encoding-Thaumaturgy\vs-tools\vstools\exceptions\dependencies.py:218: UserWarning: Optional plugin 'Eedi3' for 'lvsfunc' is not installed.
  warnings.warn(
C:\Users\light\GitHub\Jaded-Encoding-Thaumaturgy\vs-tools\vstools\exceptions\dependencies.py:218: UserWarning: Optional plugin 'Nnedi3' for 'lvsfunc' is not installed.
  warnings.warn(
```

## Drawbacks

- The biggest drawback is that vsrepo is slow. However, should something better come along, we can always update it.
- There's currently no support for installing the git latest of anything, though this feature could be added with some finesse

## Additional wants

- It would be nice if this could be done on a per-function namespace instead of just the parent namespace, but you run into the issue of heavy duplication if you do this. I've kinda worked around this by simply allowing devs to only check for specific plugins/packages instead, but better suggestions are welcome.

## To fix

- [ ] Ensure the setting in vspreview is respected. The setting exists now in https://github.com/Jaded-Encoding-Thaumaturgy/vs-preview/pull/199, but currently, it sets this after the script is loaded(?), meaning it will not respect the flag when it has to determine whether to auto-install stuff.
- [ ] When running `vspreview x.py` in a terminal, it seems to skip installing missing plugins. I think it's just completely ignoring the `check_dependencies` function, as print statements in there do not print at all?
- [ ] It should ideally only prompt for missing packages/plugins that are strictly necessary for a function run. This could be achieved through using function/class namespaces, but that quickly becomes a mess to maintain. Writing some smarter decorator or checking function is probably the way to go.