### PR TITLE
scale_8bit: Correctly map full 8-bit range

### DIFF
--- a/vstools/utils/scale.py
+++ b/vstools/utils/scale.py
@@ -29,16 +29,15 @@ def scale_8bit(clip: VideoFormatT | HoldsVideoFormatT, value: int, chroma: bool 
     """
 
     fmt = get_video_format(clip)
+    bits = get_depth(clip)
+
+    if bits == 8:
+        return value
 
     if fmt.sample_type is vs.FLOAT:
-        out = value / 255
+        return value / 255 - (0.5 if chroma else 0)
 
-        if chroma:
-            out -= .5
-
-        return out
-
-    return value << get_depth(fmt) - 8
+    return (value * ((1 << bits) - 1) + 127) // 255
 
 
 @overload


### PR DESCRIPTION
Fixes #138.

The previous implementation used a simple bitshift (value << (bits - 8)) which doesn't correctly scale the full range of 8-bit values to higher bit depths. For example, 255 << 8 results in 65280 (1111111100000000) instead of the expected 65535 (1111111111111111).

See:

```py
print(f"Simple bitshift: {(255 << 8)} ({(255 << 8):16b})")
print(f"Correct scaling: {scale_8bit(bl, 255)} ({scale_8bit(bl, 255):16b})")
```

```py
Simple bitshift: 65280 (1111111100000000)
Correct scaling: 65535 (1111111111111111)
```

This also adds a minor early exit. If the input clip is 8-bit, it just returns the given value untouched.