### PR TITLE
Assume BT.709 for UHD video

### DIFF
--- a/vstools/enums/color.py
+++ b/vstools/enums/color.py
@@ -213,10 +213,7 @@ class Matrix(_MatrixMeta):
 
             return Matrix.SMPTE170M
 
-        if width <= 2048 and height <= 1556:
-            return Matrix.BT709
-
-        return Matrix.BT2020NCL
+        return Matrix.BT709
 
     @classmethod
     def from_video(
@@ -829,10 +826,7 @@ class Primaries(_PrimariesMeta):
 
             return Primaries.SMPTE170M
 
-        if width <= 2048 and height <= 1556:
-            return Primaries.BT709
-
-        return Primaries.BT2020
+        return Primaries.BT709
 
     @classmethod
     def from_video(


### PR DESCRIPTION
The reasoning behind this change is that, if we have a BT.2020 video, it is very likely that it has been tagged with the appropriate metadata. I have not seen any videos in the wild that were intended to be BT.2020 without being tagged as such. Rather, any untagged UHD videos I have seen have been intended to be BT.709, most often due to being an upscale of a 1080p or smaller video. Because of this, BT.709 seems to be a more reasonable default in my opinion.