### PR TITLE
Small fix for type checking with pyright

### DIFF
--- a/vstools/utils/vs_enums.py
+++ b/vstools/utils/vs_enums.py
@@ -6,9 +6,9 @@ from typing import TYPE_CHECKING
 from vapoursynth import FLOAT, GRAY, INTEGER, RGB, YUV
 
 try:
-    from vapoursynth import PresetFormat as VSPresetVideoFormat
-except ImportError:
     from vapoursynth import PresetVideoFormat as VSPresetVideoFormat
+except ImportError:
+    from vapoursynth import PresetFormat as VSPresetVideoFormat
 
 from .other import IS_DOCS
 


### PR DESCRIPTION
The type checker that is included with Visual Studio Code (pyright) will only resolve imports in the try branch of a try-except statement.

This means that VSPresetVideoFormat won't be resolved if your typing stubs are up-to-date, as the correct import is in the except branch.

Swapping the try and except branches makes it work with freshly generated stubs, but will break older ones. However, since there is (seemingly) no way to make it work with both, having newer ones work seems like the better compromise to me.