### PR TITLE
Fix FunctionUtil edgecase

### DIFF
--- a/vstools/functions/funcs.py
+++ b/vstools/functions/funcs.py
@@ -154,7 +154,7 @@ class FunctionUtil(cachedproperty.baseclass, list[int]):
 
             clip = clip.resize.Bicubic(format=clip.format.replace(color_family=vs.YUV), matrix=self._matrix)
 
-        elif cfamily in (vs.YUV, vs.GRAY) and not set(self.allowed_cfamilies) & {vs.YUV, vs.GRAY}:
+        elif cfamily in (vs.YUV, vs.GRAY) and not set(self.allowed_cfamilies) & {vs.YUV, vs.GRAY} or self.planes not in (0, [0]):
             self.cfamily_converted = True
 
             clip = clip.resize.Bicubic(


### PR DESCRIPTION
If the function allowed (vs.GRAY, vs.RGB) and the input is vs.YUV with planes=[0, 1, 2] this check would previously fail to convert the YUV clip to RGB.