### PR TITLE
replace_ranges: Gut the function

### DIFF
--- a/vstools/functions/normalize.py
+++ b/vstools/functions/normalize.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Iterable, Sequence, overload
 
 import vapoursynth as vs
-from stgpytools import T, norm_display_name, norm_func_name, normalize_list_to_ranges, normalize_ranges_to_list, to_arr
+from stgpytools import T, norm_display_name, norm_func_name, normalize_list_to_ranges, to_arr
 from stgpytools import (
     flatten as stg_flatten,
     invert_ranges as stg_invert_ranges,
@@ -20,7 +20,6 @@ __all__ = [
     'to_arr',
     'flatten', 'flatten_vnodes',
     'normalize_list_to_ranges',
-    'normalize_ranges_to_list',
     'normalize_franges',
     'normalize_ranges',
     'invert_ranges',

--- a/vstools/utils/ranges.py
+++ b/vstools/utils/ranges.py
@@ -178,7 +178,7 @@ def replace_ranges(
     shift = 1 - exclusive
     b_ranges = normalize_ranges(clip_b, ranges)
 
-    a_ranges = invert_ranges(clip_b, clip_a, b_ranges)
+    a_ranges = invert_ranges(clip_a, clip_b, b_ranges)
 
     a_trims = [clip_a[max(0, start - exclusive):end + shift + exclusive] for start, end in a_ranges]
     b_trims = [clip_b[start:end + shift] for start, end in b_ranges]

--- a/vstools/utils/ranges.py
+++ b/vstools/utils/ranges.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import re
 import warnings
 from typing import Callable, Sequence, Union, overload
 
 import vapoursynth as vs
 from stgpytools import CustomValueError, flatten, interleave_arr, ranges_product
 
-from ..exceptions import FormatsMismatchError, FramerateMismatchError, LengthMismatchError, ResolutionsMismatchError
 from ..functions import check_ref_clip
 from ..types import FrameRangeN, FrameRangesN
 
@@ -21,8 +19,6 @@ __all__ = [
     'ranges_product',
 
     'interleave_arr',
-
-    'convert_rfs',
 ]
 
 
@@ -237,40 +233,3 @@ def replace_every(
     interleaved = vs.core.std.Interleave([clipa, clipb])
 
     return interleaved.std.SelectEvery(cycle * 2, offsets, modify_duration)
-
-
-def convert_rfs(rfs_string: str) -> FrameRangesN:
-    """
-    Convert `ReplaceFramesSimple`-styled ranges to `replace_ranges`-styled ranges.
-
-    This function accepts RFS ranges as a string, consistent with RFS handling.
-    The input string is validated before processing.
-
-    Supports both '[x y]' and 'x' frame numbering styles.
-    Returns an empty list if no valid frames are found.
-
-    :param rfs_string:          A string representing frame ranges in ReplaceFramesSimple format.
-
-    :return:                    A FrameRangesN list containing frame ranges compatible with `replace_ranges`.
-                                Returns an empty list if no valid frames are found.
-
-    :raises CustomValueError:   If the input string contains invalid characters.
-    """
-
-    rfs_string = str(rfs_string).strip()
-
-    if not rfs_string:
-        return []
-
-    valid_chars = set('0123456789[] ')
-    illegal_chars = set(rfs_string) - valid_chars
-
-    if illegal_chars:
-        reason = ', '.join(f"{c}:{rfs_string.index(c)}" for c in sorted(illegal_chars, key=rfs_string.index))
-
-        raise CustomValueError('Invalid characters found in input string!', convert_rfs, reason)
-
-    return [
-        int(match[2]) if match[2] else (int(match[0]), int(match[1]))
-        for match in re.findall(r'\[(\d+)\s+(\d+)\]|(\d+)', rfs_string)
-    ]

--- a/vstools/utils/ranges.py
+++ b/vstools/utils/ranges.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from typing import Callable, Sequence, Union, overload
 
 import vapoursynth as vs
@@ -178,13 +177,6 @@ def replace_ranges(
         raise CustomValueError(
             f'You cannot replace frames that are out of bounds ({min_frame_num=})!',
             replace_ranges, [r for r in b_ranges if r[1] >= min_frame_num]
-        )
-
-    if clip_a.num_frames != clip_b.num_frames:
-        warnings.warn(
-            f"replace_ranges: 'The number of frames of the clips don't match! "
-            f"({clip_a.num_frames=}, {clip_b.num_frames=})\n"
-            "The function will still work, but you may run into undefined behavior, or a broken output clip!'"
         )
 
     if not do_splice_trim:


### PR DESCRIPTION
As requested by Zewia:

- Remove the outdated plugins
- Use vszip plugin
- Remove hack to force same-length clips since vszip doesnt have this issue
- Remove the old `convert_rfs` function for converting remap-style ranges to replace_ranges-style ranges

Things I'm uncertain about:

- [x] What happens if the user doesn't have vs-zip installed and has more than 15 splices? Does it enter an endless recursion?
- [x] Is the splicing still faster? If yes, when does vs-zip start outperforming it?