### PR TITLE
Use `with x.get_frame` instead of `x.get_frame` globally

### DIFF
--- a/vstools/enums/other.py
+++ b/vstools/enums/other.py
@@ -175,7 +175,7 @@ class Sar(Fraction):
             props = clip.props
         elif isinstance(clip, vs.RawNode):
             with clip.get_frame(0) as frame:
-                props = frame.props
+                props = frame.props.copy()
         else:
             props = clip
 

--- a/vstools/enums/other.py
+++ b/vstools/enums/other.py
@@ -174,7 +174,8 @@ class Sar(Fraction):
         if isinstance(clip, vs.RawFrame):
             props = clip.props
         elif isinstance(clip, vs.RawNode):
-            props = clip.get_frame(0).props
+            with clip.get_frame(0) as frame:
+                props = frame.props
         else:
             props = clip
 

--- a/vstools/exceptions/color.py
+++ b/vstools/exceptions/color.py
@@ -60,7 +60,8 @@ class InvalidColorspacePathError(CustomValueError):
         """
 
         try:
-            to_check.get_frame(0)
+            with to_check.get_frame(0):
+                pass
         except vs.Error as e:
             if 'no path between colorspaces' in str(e):
                 raise InvalidColorspacePathError(func, e)

--- a/vstools/exceptions/color.py
+++ b/vstools/exceptions/color.py
@@ -60,8 +60,7 @@ class InvalidColorspacePathError(CustomValueError):
         """
 
         try:
-            with to_check.get_frame(0):
-                pass
+            to_check.get_frame(0).close()
         except vs.Error as e:
             if 'no path between colorspaces' in str(e):
                 raise InvalidColorspacePathError(func, e)

--- a/vstools/functions/heuristics.py
+++ b/vstools/functions/heuristics.py
@@ -60,7 +60,7 @@ def video_heuristics(
 
     if props is True:
         with clip.get_frame(0) as frame:
-            props_dict = frame.props
+            props_dict = frame.props.copy()
     else:
         props_dict = props or None
 

--- a/vstools/functions/heuristics.py
+++ b/vstools/functions/heuristics.py
@@ -59,7 +59,8 @@ def video_heuristics(
     heuristics = dict[str, PropEnum]()
 
     if props is True:
-        props_dict = clip.get_frame(0).props
+        with clip.get_frame(0) as frame:
+            props_dict = frame.props
     else:
         props_dict = props or None
 

--- a/vstools/utils/info.py
+++ b/vstools/utils/info.py
@@ -30,7 +30,8 @@ def get_var_infos(frame: vs.VideoNode | vs.VideoFrame) -> tuple[vs.VideoFormat, 
     if isinstance(frame, vs.VideoNode) and not (
         frame.width and frame.height and frame.format
     ):
-        frame = frame.get_frame(0)
+        with frame.get_frame(0) as frame:
+            pass
 
     assert frame.format
 

--- a/vstools/utils/info.py
+++ b/vstools/utils/info.py
@@ -31,7 +31,7 @@ def get_var_infos(frame: vs.VideoNode | vs.VideoFrame) -> tuple[vs.VideoFormat, 
         frame.width and frame.height and frame.format
     ):
         with frame.get_frame(0) as frame:
-            pass
+            return get_var_infos(frame)
 
     assert frame.format
 

--- a/vstools/utils/misc.py
+++ b/vstools/utils/misc.py
@@ -85,10 +85,10 @@ def match_clip(
         clip = clip.resize.Bicubic(format=ref.format.id, matrix=Matrix.from_video(ref))
 
     if matrices:
-        ref_frame = ref.get_frame(0)
-        clip = clip.std.SetFrameProps(
-            _Matrix=Matrix(ref_frame), _Transfer=Transfer(ref_frame), _Primaries=Primaries(ref_frame)
-        )
+        with ref.get_frame(0) as ref_frame:
+            clip = clip.std.SetFrameProps(
+                _Matrix=Matrix(ref_frame), _Transfer=Transfer(ref_frame), _Primaries=Primaries(ref_frame)
+            )
 
     return clip.std.AssumeFPS(fpsnum=ref.fps.numerator, fpsden=ref.fps.denominator)
 

--- a/vstools/utils/props.py
+++ b/vstools/utils/props.py
@@ -87,7 +87,7 @@ def get_prop(
 
     try:
         try:
-            prop = props.get(key, MISSING)
+            prop = props[key]
         except Exception:
             if isinstance(key, type) and issubclass(key, PropEnum):
                 key = key.prop_key

--- a/vstools/utils/props.py
+++ b/vstools/utils/props.py
@@ -79,7 +79,7 @@ def get_prop(
         props = obj.props
     elif isinstance(obj, vs.RawNode):
         with obj.get_frame(0) as frame:
-            props = frame.props
+            props = frame.props.copy()
     else:
         props = obj
 
@@ -87,7 +87,7 @@ def get_prop(
 
     try:
         try:
-            prop = props[key]
+            prop = props.get(key, MISSING)
         except Exception:
             if isinstance(key, type) and issubclass(key, PropEnum):
                 key = key.prop_key

--- a/vstools/utils/props.py
+++ b/vstools/utils/props.py
@@ -78,7 +78,8 @@ def get_prop(
     if isinstance(obj, vs.RawFrame):
         props = obj.props
     elif isinstance(obj, vs.RawNode):
-        props = obj.get_frame(0).props
+        with obj.get_frame(0) as frame:
+            props = frame.props
     else:
         props = obj
 

--- a/vstools/utils/vs_proxy.py
+++ b/vstools/utils/vs_proxy.py
@@ -169,12 +169,10 @@ def clear_cache() -> None:
         try:
             for output in get_outputs().values():
                 if isinstance(output, VideoOutputTuple):
-                    with output.clip.get_frame(0):
-                        pass
+                    output.clip.get_frame(0).close()
                     break
         except Exception:
-            with core.std.BlankClip().get_frame(0):
-                pass
+            core.std.BlankClip().get_frame(0).close()
         core.max_cache_size = cache_size
     except Exception:
         ...

--- a/vstools/utils/vs_proxy.py
+++ b/vstools/utils/vs_proxy.py
@@ -169,10 +169,12 @@ def clear_cache() -> None:
         try:
             for output in get_outputs().values():
                 if isinstance(output, VideoOutputTuple):
-                    output.clip.get_frame(0)
+                    with output.clip.get_frame(0):
+                        pass
                     break
         except Exception:
-            core.std.BlankClip().get_frame(0)
+            with core.std.BlankClip().get_frame(0):
+                pass
         core.max_cache_size = cache_size
     except Exception:
         ...


### PR DESCRIPTION
This should help prevent some minor memory leaks. Since it only happens upon init, the memory leaks ultimately shouldn't get worse over time (unless called in i.e. a frame eval). However, since a lot of functions call `get_prop`, this might negatively impact memory for scripts that depend on a lot of these functions.