### PR TITLE
Add a frame props cache in get_prop

### DIFF
--- a/vstools/utils/cache.py
+++ b/vstools/utils/cache.py
@@ -77,13 +77,15 @@ class FramesCache(vs_object, Generic[NodeT, FrameT], dict[int, FrameT]):
 
     def __getitem__(self, __key: int) -> FrameT:
         if __key not in self:
-            self.add_frame(__key, self.clip.get_frame(__key))
+            self.add_frame(__key, cast(FrameT, self.clip.get_frame(__key)))
 
         return super().__getitem__(__key)
 
     def __vs_del__(self, core_id: int) -> None:
         self.clear()
-        self.clip = None
+
+        if not TYPE_CHECKING:
+            self.clip = None
 
 
 class NodeFramesCache(vs_object, dict[NodeT, FramesCache[NodeT, FrameT]]):

--- a/vstools/utils/cache.py
+++ b/vstools/utils/cache.py
@@ -8,6 +8,12 @@ from ..functions import Keyframes
 from ..types import vs_object
 from . import vs_proxy as vs
 
+if TYPE_CHECKING:
+    from vapoursynth import _VapourSynthMapValue
+else:
+    _VapourSynthMapValue = Any
+
+
 __all__ = [
     'ClipsCache',
 
@@ -20,6 +26,8 @@ __all__ = [
     'ClipFramesCache',
 
     'SceneBasedDynamicCache',
+
+    'NodesPropsCache',
 
     'cache_clip'
 ]
@@ -127,6 +135,17 @@ class SceneBasedDynamicCache(DynamicClipsCache[int]):
     @classmethod
     def from_clip(cls, clip: vs.VideoNode, keyframes: Keyframes | str, *args: Any, **kwargs: Any) -> vs.VideoNode:
         return cls(clip, keyframes, *args, **kwargs).get_eval()
+
+
+class NodesPropsCache(vs_object, dict[tuple[NodeT, int], MutableMapping[str, _VapourSynthMapValue]]):
+    def __delitem__(self, __key: tuple[NodeT, int]) -> None:
+        if __key not in self:
+            return
+
+        return super().__delitem__(__key)
+
+    def __vs_del__(self, core_id: int) -> None:
+        self.clear()
 
 
 def cache_clip(_clip: NodeT, cache_size: int = 10) -> NodeT:


### PR DESCRIPTION
Following #171 , this PR adds a cache to speed up `get_prop` function. 
According to my tests on a real world scenario script, 91 `get_prop` calls were done and adding the cache speeds up the script evaluation by around 20 %.